### PR TITLE
make the SMF script match the example config's pid file path

### DIFF
--- a/build/nginx/files/http-nginx
+++ b/build/nginx/files/http-nginx
@@ -30,7 +30,7 @@
 source /lib/svc/share/smf_include.sh
 
 typeset -r CONF_FILE="/opt/nginx/conf/nginx.conf"
-typeset -r PIDFILE="/var/run/nginx.pid"
+typeset -r PIDFILE="/opt/nginx/logs/nginx.pid"
 typeset -r NGINX="/opt/nginx/sbin/nginx"
 
 [[ ! -f ${CONF_FILE} ]] && exit $SMF_EXIT_ERR_CONFIG


### PR DESCRIPTION
conf/nginx.conf.{default,dist} have a pid file path of 'logs/nginx.pid', this has the start/stop script look there instead of /var/run/nginx.pid
