### PR TITLE
Do pkgdepend before publishing

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -594,9 +594,9 @@ make_package() {
         $PKGDEPEND generate -md $DESTDIR $P5M_INT2 > $P5M_INT3
         $PKGDEPEND resolve -m $P5M_INT3
     ) || logerr "--- Dependency resolution failed"
+    echo > "$MANUAL_DEPS"
     if [[ -n "$DEPENDS_IPS" ]]; then
         logmsg "--- Adding manual dependencies"
-        echo > "$MANUAL_DEPS"
         for i in $DEPENDS_IPS; do
             # IPS dependencies have multiple types, of which we care about four:
             #    require, optional, incorporate, exclude


### PR DESCRIPTION
This helps to find out the correct dependencies for packages automatically.

pkgdepend does slow down the packaging process, of course. I didn't implement it, but if you wanted to amortize pkgdepend runs between multiple builds or just debug building some package quickly, build.sh could have a command line argument to skip the depend phase.
