### PR TITLE
remove proto from dlmirror (thus allowing ftp)

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -478,7 +478,7 @@ get_resource() {
             logcmd cp $MIRROR/$RESOURCE .
             ;;
         *)
-            URLPREFIX=http://$MIRROR
+            URLPREFIX=$MIRROR
             $WGET -a $LOGFILE $URLPREFIX/$RESOURCE
             ;;
     esac


### PR DESCRIPTION
wget uses http by default, so by removing the protocol from the URL we can support other protocols for source downloads (eg. MIRROR=ftp://ftp.mutt.org)
