### PR TITLE
bump nginx to latest (1.2.8)

### DIFF
--- a/build/nginx/build.sh
+++ b/build/nginx/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=nginx
-VER=1.2.7
+VER=1.2.8
 VERHUMAN=$VER
 PKG=omniti/server/nginx
 SUMMARY="nginx web server"


### PR DESCRIPTION
This has been tested against an up-to-date OmniOS stable installation.
