### PR TITLE
bump nginx to latest 1.2 series (1.2.9)

### DIFF
--- a/build/nginx/build.sh
+++ b/build/nginx/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=nginx
-VER=1.2.8
+VER=1.2.9
 VERHUMAN=$VER
 PKG=omniti/server/nginx
 SUMMARY="nginx web server"


### PR DESCRIPTION
Bumping to 1.2.9 fixes CVE-2013-2070, but this is now the 'legacy' release series.

I'm looking into jumping up to 1.4 (new stable series) shortly if that's not expected to break anything.
