### PR TITLE
upgrade to current stable series (1.4.x)

### DIFF
--- a/build/nginx/build.sh
+++ b/build/nginx/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=nginx
-VER=1.2.8
+VER=1.4.1
 VERHUMAN=$VER
 PKG=omniti/server/nginx
 SUMMARY="nginx web server"


### PR DESCRIPTION
Tested 1.4.1 on r151006c using my configuration for static content serving and IPS proxy from nginx 1.2.x.

Builds and runs fine with no changes to build configuration or installed server configuration.

Feel free to close the 1.2.x pull request without merging if this one is okay.

Thanks!
