### PR TITLE
Don't overwrite configuration files when upgrading packages

### DIFF
--- a/lib/global-transforms.mog
+++ b/lib/global-transforms.mog
@@ -100,3 +100,5 @@
 # If you ship an SMF manifest, it should be imported upon pkg install
 <transform file path=(var|lib)/svc/manifest/.*\.xml -> \
     add restart_fmri svc:/system/manifest-import:default>
+
+<transform file path=etc/ -> set preserve renamenew>


### PR DESCRIPTION
I think it would make sense to add this global transform to prevent IPS from overwriting config files (I'm assuming those are in etc/) on package upgrades. pkg(5) man page has more details on the file action's preserve attribute.
