### PR TITLE
don't --disable-getifaddrs for ntp

### DIFF
--- a/build/ntp/build.sh
+++ b/build/ntp/build.sh
@@ -54,7 +54,6 @@ CONFIGURE_OPTS_32="--prefix=/usr
     --without-sntp
     --without-lineeditlibs
     --with-openssl-libdir=/lib
-    --disable-getifaddrs
 "
 
 overlay_root() {


### PR DESCRIPTION
This should fix 'Cannot bind to requested address' spam for ipv6
link-local addresses from ntpd.

See http://bugs.ntp.org/show_bug.cgi?id=2243 for this issue. Allowing ntp to use getifaddrs resolves this; I'm not sure why it is built with that flag currently.
