### PR TITLE
rsyslog 7.4.3 stable with Guardtime support

### DIFF
--- a/build/guardtime/build.sh
+++ b/build/guardtime/build.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/bash
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2011-2013 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=gtime
+VER=1.0-12
+VERHUMAN=$VER
+PKG=omniti/security/guardtime
+SUMMARY="Commandline client for Guardtime Keyless Signature Service"
+DESC="$SUMMARY"
+
+BUILD_DEPENDS_IPS="omniti/security/libguardtime"
+DEPENDS_IPS="omniti/security/libguardtime"
+
+CFLAGS="-I/opt/omni/include"
+LDFLAGS="-L/opt/omni/lib -R/opt/omni/lib"
+CFLAGS64="-I/usr/include/amd64 $CFLAGS64"
+LDFLAGS64="-L/opt/omni/lib/amd64 -R/opt/omni/lib/amd64"
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+make_isa_stub
+VER=1.0.12
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:

--- a/build/guardtime/local.mog
+++ b/build/guardtime/local.mog
@@ -1,0 +1,2 @@
+#No License file
+#license COPYING license=Apache2

--- a/build/libguardtime/build.sh
+++ b/build/libguardtime/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/bash
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2011-2013 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=libgt
+VER=0.3.11
+VERHUMAN=$VER
+PKG=omniti/security/libguardtime
+SUMMARY="Guardtime Client C SDK"
+DESC="$SUMMARY"
+
+BUILD_DEPENDS_IPS="library/security/openssl web/curl"
+DEPENDS_IPS="library/security/openssl web/curl"
+
+CFLAGS="$CFLAGS -I/opt/omni/include"
+CFLAGS64="-I/usr/include/amd64 $CFLAGS64"
+
+init
+download_source $PROG $PROG $VER-src
+patch_source
+prep_build
+build
+make_isa_stub
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:

--- a/build/libguardtime/local.mog
+++ b/build/libguardtime/local.mog
@@ -1,0 +1,3 @@
+license opt/omni/share/doc/libgt/license.txt license=Apache2
+license opt/omni/share/doc/libgt/license.curl.txt license=BSD
+license opt/omni/share/doc/libgt/license.openssl.txt license=BSD

--- a/build/python26-docutils/build.sh
+++ b/build/python26-docutils/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/bash
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2011-2013 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=docutils
+VER=0.10
+VERHUMAN=$VER
+PKG=omniti/library/python-2/docutils
+SUMMARY="Python text processing system"
+DESC="$SUMMARY"
+
+BUILD_DEPENDS_IPS="omniti/runtime/python-26"
+DEPENDS_IPS="omniti/runtime/python-26"
+
+BUILDARCH=64
+PYTHON=/opt/python26/bin/python
+LDFLAGS64="-L$PYTHONLIB -R$PYTHONLIB -L/opt/omni/lib/$ISAPART64 -R/opt/omni/lib/$ISAPART64"
+PATH=/opt/omni/bin:/opt/python26/bin:$PATH
+
+link_bins() {
+    logmsg "--- Symlinking binaries"
+    pushd ${DESTDIR}/opt/python26/bin
+    for BIN in `ls *.py` ; do
+        NEWBIN=$(basename $BIN | cut -d. -f1)
+        logcmd ln -sf $BIN $NEWBIN
+    done
+    popd
+}
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+python_build
+link_bins
+make_package
+clean_up

--- a/build/rsyslog/build.sh
+++ b/build/rsyslog/build.sh
@@ -28,33 +28,62 @@
 . ../../lib/functions.sh
 
 PROG=rsyslog
-VER=7.3.9
+VER=7.4.3
 VERDEV=7
-VERHUMAN="$VER (v${VERDEV}-devel)"
+VERHUMAN="$VER (v${VERDEV}-stable)"
 PKG=omniti/logging/rsyslog
 SUMMARY="The enhanced syslogd for Linux and Unix"
 DESC="$SUMMARY"
 
-BUILD_DEPENDS_IPS="omniti/library/libee omniti/library/libestr omniti/library/json-c omniti/library/uuid"
-DEPENDS_IPS="omniti/library/libee omniti/library/libestr omniti/library/json-c omniti/library/uuid"
+BUILD_DEPENDS_IPS="developer/parser/bison omniti/library/python-2/docutils library/security/openssl omniti/security/libguardtime omniti/security/guardtime omniti/library/libee omniti/library/libestr omniti/library/json-c omniti/library/uuid"
+DEPENDS_IPS="library/security/openssl omniti/security/libguardtime omniti/security/guardtime omniti/library/libee omniti/library/libestr omniti/library/json-c omniti/library/uuid"
 
-BUILDARCH=64
 CFLAGS="-I/opt/omni/include"
+CFLAGS64="-I/usr/include/amd64 -I/opt/omni/include/amd64 $CFLAGS64"
 LDFLAGS64="-L/opt/omni/lib/$ISAPART64 -R/opt/omni/lib/$ISAPART64"
-LIBESTR_CFLAGS="$CFLAGS"
-LIBESTR_LIBS="$LDFLAGS64 -lestr"
-LIBEE_CFLAGS="$CFLAGS"
-LIBEE_LIBS="$LDFLAGS64 -lee"
-JSON_C_CFLAGS="$CFLAGS"
-JSON_C_LIBS="$LDFLAGS64 -ljson-c"
-LIBUUID_CFLAGS="$CFLAGS"
-LIBUUID_LIBS="$LDFLAGS64 -luuid"
-export LIBESTR_CFLAGS LIBESTR_LIBS \
-       LIBEE_CFLAGS LIBEE_LIBS \
-       JSON_C_CFLAGS JSON_C_LIBS \
-       LIBUUID_CFLAGS LIBUUID_LIBS
 
-CONFIGURE_OPTS="--enable-imfile --enable-imsolaris"
+
+CONFIGURE_OPTS="--enable-imfile --enable-imsolaris --enable-guardtime --enable-diagtools --enable-usertools"
+
+build32_opts() {
+    CFLAGS="-DHAVE_LSEEK64 -I/opt/omni/include"
+    LDFLAGS="-L/opt/omni/lib -R/opt/omni/lib"
+    LIBESTR_CFLAGS="$CFLAGS"
+    LIBESTR_LIBS="$LDFLAGS -lestr"
+    LIBEE_CFLAGS="$CFLAGS"
+    LIBEE_LIBS="$LDFLAGS -lee"
+    JSON_C_CFLAGS="$CFLAGS"
+    JSON_C_LIBS="$LDFLAGS -ljson-c"
+    LIBUUID_CFLAGS="$CFLAGS"
+    LIBUUID_LIBS="$LDFLAGS -luuid"
+    GUARDTIME_CFLAGS="$CFLAGS"
+    GUARDTIME_LIBS="$LDFLAGS -lgtbase -lgthttp -lgtpng"
+    export LIBESTR_CFLAGS LIBESTR_LIBS \
+           LIBEE_CFLAGS LIBEE_LIBS \
+           JSON_C_CFLAGS JSON_C_LIBS \
+           LIBUUID_CFLAGS LIBUUID_LIBS \
+           GUARDTIME_CFLAGS GUARDTIME_LIBS
+    export PATH=/opt/omni/bin:/opt/python26/bin:$PATH
+}
+
+build64_opts() {
+    LIBESTR_CFLAGS="$CFLAGS"
+    LIBESTR_LIBS="$LDFLAGS64 -lestr"
+    LIBEE_CFLAGS="$CFLAGS"
+    LIBEE_LIBS="$LDFLAGS64 -lee"
+    JSON_C_CFLAGS="$CFLAGS"
+    JSON_C_LIBS="$LDFLAGS64 -ljson-c"
+    LIBUUID_CFLAGS="$CFLAGS"
+    LIBUUID_LIBS="$LDFLAGS64 -luuid"
+    GUARDTIME_CFLAGS="$CFLAGS"
+    GUARDTIME_LIBS="$LDFLAGS64 -lgtbase -lgthttp -lgtpng"
+    export LIBESTR_CFLAGS LIBESTR_LIBS \
+           LIBEE_CFLAGS LIBEE_LIBS \
+           JSON_C_CFLAGS JSON_C_LIBS \
+           LIBUUID_CFLAGS LIBUUID_LIBS \
+           GUARDTIME_CFLAGS GUARDTIME_LIBS
+    export PATH=/opt/omni/bin/amd64:/usr/bin/amd64:/opt/python26/bin:$PATH
+}
 
 copy_manifest() {
     # SMF manifest
@@ -64,10 +93,13 @@ copy_manifest() {
 }
 
 init
-download_source $PROG $PROG ${VER}-v7-devel
+download_source $PROG $PROG ${VER}
 patch_source
 prep_build
-build
+build32_opts
+build32
+build64_opts
+build64
 make_isa_stub
 copy_manifest
 VER=${VER}.${VERDEV}


### PR DESCRIPTION
Dependencies libguardtime (Guardtime C SDK) guardtime (Guardtime Client
utility) python26-docutils (build dep, generate man pages)

rsyslog diag and user tools have been enabled and all pkgs are both 32 and 64
enabled
