### PR TITLE
fix dropping gnu info dir files

### DIFF
--- a/lib/global-transforms.mog
+++ b/lib/global-transforms.mog
@@ -41,7 +41,7 @@
 <transform dir path=usr/share/locale$ -> set group other>
 
 # drop GNU info dir files
-<transform file path=share/info/dir$ -> drop>
+<transform file path=.*/share/info/dir$ -> drop>
 
 # Libtool archives can suck it
 <transform file path=.*/lib/.*\.la$ -> drop>


### PR DESCRIPTION
pkgmogrify patterns are anchored at the beginning, so the current global transform to drop gnu info dir files does not work. This should fix that.
