### PR TITLE
Fixed typo (missing "wrapper" in name)

### DIFF
--- a/build/swig/build.sh
+++ b/build/swig/build.sh
@@ -30,7 +30,7 @@
 PROG=swig
 VER=2.0.11
 PKG=developer/swig
-SUMMARY="The Simplified and Interface Generator (swig)"
+SUMMARY="The Simplified Wrapper and Interface Generator (swig)"
 DESC="$SUMMARY"
 
 BUILD_DEPENDS_IPS="runtime/perl runtime/python-26"


### PR DESCRIPTION
Hello, I just noticed that "Wrapper" was missing in the `SUMMARY`, so I figured I'd fix it up and send a pull request.

Cheers!
