### PR TITLE
Fix for http://omnios.omniti.com/ticket.php/83 'libgmp problems in 151008'

### DIFF
--- a/build/gcc48/build-libgmp.sh
+++ b/build/gcc48/build-libgmp.sh
@@ -44,7 +44,8 @@ PKGPREFIX=""
 [[ "$BUILDARCH" == "both" ]] && BUILDARCH=32
 PREFIX=/opt/gcc-${GCCVER}
 CC=gcc
-CONFIGURE_OPTS="--enable-cxx"
+# '--disable-assembly' fixes http://omnios.omniti.com/ticket.php/83
+CONFIGURE_OPTS="--enable-cxx --disable-assembly"
 CFLAGS="-fexceptions"
 ABI=32
 export ABI


### PR DESCRIPTION
This fixes the unresolved symbol in libgmp.so (__gmpn_invert_limb) as detailed in http://omnios.omniti.com/ticket.php/83 need by some applications (like tesseract-ocr). I must admit that my compiler and linking foo is relativly weak. This fixes the problem for me but I cannot oversee what other consequences adding this flag has.
