### PR TITLE
31487 pkg-build-gate can use local mirror

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -10,7 +10,10 @@ fi
 
 [ "${1}" == "licenses" ] && AUDIT_LICENSE=1
 
+# targets maps any valid package name to its build script.
 declare -A targets
+# fulltargets maps full package names to their build script.
+declare -A fulltargets
 declare -A licenses
 TCNT=0
 for build in */build*.sh
@@ -30,6 +33,15 @@ do
             print -f "."
         else
             targets+=([$PKG]=$build)
+            fulltargets+=([$PKG]=$build)
+            #
+            # Repeatedly strip off leading components to generate all valid
+            # names for this package.
+            #
+            while [[ $PKG =~ '/' ]]; do
+                PKG=${PKG#*/}
+                targets+=([$PKG]=$build)
+            done
         fi
     done
 done
@@ -58,7 +70,7 @@ bail() {
 
 list() {
     PAT=${1-.}
-    for target in "${!targets[@]}"
+    for target in "${!fulltargets[@]}"
     do
         if [[ "$PAT" = "." ]]; then
             echo " * $target"
@@ -106,7 +118,8 @@ build() {
                 rm $SCRIPT.final
             fi
         else
-            PATH=$PATH:. $SCRIPT $batch_flag
+            PATH=$PATH:. $SCRIPT -r $PKGSRVR $batch_flag || \
+                logerr "Unable to run $SCRIPT"
         fi
     popd >/dev/null
 }

--- a/build/git/build.sh
+++ b/build/git/build.sh
@@ -23,6 +23,7 @@
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright (c) 2014 by Delphix. All rights reserved.
 #
 # Load support functions
 . ../../lib/functions.sh
@@ -66,7 +67,7 @@ install_man() {
     logmsg "Fetching and installing pre-built man pages"
     if [[ ! -f ${TMPDIR}/${PROG}-manpages-${VER}.tar.gz ]]; then
         pushd $TMPDIR > /dev/null
-        logcmd $WGET -a $LOGFILE http://$MIRROR/$PROG/${PROG}-manpages-${VER}.tar.gz || \
+        get_resource $PROG/${PROG}-manpages-${VER}.tar.gz || \
             logerr "--- Failed to fetch tarball"
         popd > /dev/null
     fi

--- a/build/openjdk/build.sh
+++ b/build/openjdk/build.sh
@@ -23,6 +23,7 @@
 #
 # Copyright 2011-2013 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright (c) 2014 by Delphix. All rights reserved.
 #
 # Load support functions
 . ../../lib/functions.sh
@@ -79,7 +80,9 @@ download_hg() {
 install_cups_headers() {
     logmsg "Installing CUPS headers for build"
     pushd $TMPDIR > /dev/null
-    curl -s http://$MIRROR/cups/cups-headers.tar.gz | gzip -dc | tar xf - || \
+    get_resource cups/cups-headers.tar.gz || \
+        logerr "--- Failed to download cups-headers tarball"
+    extract_archive cups-headers.tar.gz || \
         logerr "--- Failed to extract cups-headers tarball"
     popd > /dev/null
 }
@@ -87,7 +90,9 @@ install_cups_headers() {
 install_x11_headers() {
     logmsg "Installing openwin bits for build"
     pushd $TMPDIR > /dev/null
-    curl http://$MIRROR/Xstuff/openwin.tar.gz | gzip -dc | tar xvf - || \
+    get_resource Xstuff/openwin.tar.gz || \
+        logerr "--- Failed to download openwin tarball"
+    extract_archive openwin.tar.gz || \
         logerr "--- Failed to extract openwin tarball"
     popd > /dev/null
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -22,6 +22,7 @@
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright (c) 2014 by Delphix. All rights reserved.
 #
 #############################################################################
 # Configuration for the build system
@@ -31,7 +32,8 @@
 RELVER=151009
 PVER=0.$RELVER
 
-# Which server to fetch files from
+# Which server to fetch files from.
+# If $MIRROR begins with a '/', it is treated as a local directory.
 MIRROR=mirrors.omniti.com
 
 # Default prefix for packages (may be overridden)

--- a/lib/global-transforms.mog
+++ b/lib/global-transforms.mog
@@ -22,6 +22,7 @@
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright (c) 2014 by Delphix. All rights reserved.
 #
 # Make all directories usable
 <transform dir -> default mode 0755>
@@ -58,6 +59,7 @@
 <transform dir path=usr/share/aclocal$ -> set group other>
 <transform dir path=usr/share/lib$ -> set group sys>
 <transform dir path=var/lib$ -> set group other>
+<transform dir path=sbin$ -> set group sys>
 
 # These always exist due to SUNWcs, so we never need to worry about them
 <transform dir path=opt$ -> drop>


### PR DESCRIPTION
This actually addresses a number of issues:
- pkg-build-gate can use a local mirror
- run pkglint after generating a package
- can specify the repository to upload to
- can build a package w/o the full fmri
