### PR TITLE
Strip the fmri

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -627,7 +627,9 @@ make_package() {
     if [[ -z "$NO_AUTO_DEPENDS" ]]; then
         $PKGDEPEND generate -d $DESTDIR $P5M_INT.stage1 > $P5M_INT.dep
         $PKGDEPEND resolve $P5M_INT.dep
-        cat $P5M_INT.dep.res >> $P5M_INT.stage1
+        # Strip the OS version, etc from the fmri.
+        sed -E '/^depend fmri/ s/@([^ :,-]*)[^ ]*/@\1/' $P5M_FINAL.dep.res >> \
+            $P5M_INT.stage1
         # Incorporate on entire so that a newer build for an earlier release 
         # won't install on a later release.
         echo "depend fmri=pkg:/entire@11-$PVER type=incorporate" >> $P5M_INT.stage1


### PR DESCRIPTION
I believe this fixes a nightmare dependency problem. In short, I have a 151008 vm on which I can no longer install the latest version of postgres 9.2. I can install `postgresql-924` but not `postgresql-926`: https://gist.github.com/awreece/9030349. 

If you compare the dependencies in the [`postgresql-924` manifest](http://pkg.omniti.com/omniti-ms/manifest/0/omniti%2Fdatabase%2Fpostgresql-924%409.2.4%2C5.11-0.151004%3A20130404T135800Z) and the  [`postgresql-925` manifest](http://pkg.omniti.com/omniti-ms/manifest/0/omniti%2Fdatabase%2Fpostgresql-925%409.2.5%2C5.11-0.151006%3A20131018T211214Z), you see a remarkable difference:

```
$ grep '^depend fmri' postgresql-924.mf
depend fmri=omniti/database/postgresql/common type=require
depend fmri=system/library/gcc-4-runtime type=require

$ grep '^depend fmri' postgresql-925.mf
depend fmri=pkg:/entire@11-0.151006 type=incorporate
depend fmri=omniti/database/postgresql/common type=require
depend fmri=pkg:/SUNWcs@0.5.11-0.151006 type=require
depend fmri=pkg:/library/libxml2@2.9.0-0.151006 type=require
depend fmri=pkg:/library/readline@6.2-0.151006 type=require
depend fmri=pkg:/library/security/openssl@1.0.1.5-0.151006 type=require
depend fmri=pkg:/library/zlib@1.2.7-0.151006 type=require
depend fmri=pkg:/system/library/gcc-4-runtime@4.7.2-0.151006 type=require
depend fmri=pkg:/system/library/math@0.5.11-0.151006 type=require
depend fmri=pkg:/system/library@0.5.11-0.151006 type=require
depend fmri=system/library/gcc-4-runtime type=require
```

I don't know what is necessary to do with the entire incorporation, but I believe you need to strip the os component from the fmris for the other dependencies.
