### PR TITLE
31487 pkg-build-gate can use local mirror (build all does fulltargets)

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -164,7 +164,7 @@ case "$1" in
 	tobuild=$*
 	if [ -z "$tobuild" ] || [ "$tobuild" == "all" ]; then
 		batch_flag="-b"
-		for tgt in "${!targets[@]}"; do
+		for tgt in "${!fulltargets[@]}"; do
 			build $tgt
 		done
 	else


### PR DESCRIPTION
31487 pkg-build-gate can use local mirror (build all does fulltargets)
