### PR TITLE
31656 create build script for open-vm-tools

### DIFF
--- a/build/open-vm-tools/build.sh
+++ b/build/open-vm-tools/build.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/bash
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2014 by Delphix. All rights reserved.
+#
+
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=open-vm-tools
+BUILDDIR=open-vm-tools-9.4.0-1280544
+VER=9.4.0
+VERHUMAN=9.4.0
+PKG=system/virtualization/open-vm-tools
+SUMMARY="Open Virtual Machine Tools"
+DESC="The Open Virtual Machine Tools project aims to provide a suite of open source virtualization utilities and drivers to improve the functionality and user experience of virtualization. The project currently runs in guest operating systems under the VMware hypervisor."
+
+BUILD_DEPENDS_IPS='developer/pkg-config'
+RUN_DEPENDS_IPS='library/glib2 system/library/gcc-4-runtime'
+
+install_smf() {
+	logmsg "Installing SMF components"
+	logcmd mkdir -p $DESTDIR/lib/svc/manifest/system/virtualization || \
+		logerr "--- Failed to create manifest directory"
+	logcmd cp $SRCDIR/open-vm-tools.xml $DESTDIR/lib/svc/manifest/system/virtualization/ || \
+		logerr "--- Failed to copy manifest file"
+}
+
+CFLAGS=-Wno-deprecated-declarations
+CONFIGURE_OPTS="
+	--without-kernel-modules
+	--disable-static
+	--without-x
+	--without-dnet
+	--without-icu
+	--without-gtk2
+	--without-gtkmm
+"
+BUILDARCH=32
+
+init
+download_source $PROG $PROG $VER
+prep_build
+build
+install_smf
+make_isa_stub
+make_package
+clean_up

--- a/build/open-vm-tools/local.mog
+++ b/build/open-vm-tools/local.mog
@@ -1,0 +1,44 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2014 by Delphix. All rights reserved.
+#
+
+license COPYING license="LGPLv2"
+set name=info.classification value="org.opensolaris.category.2008:System/Virtualization"
+<transform dir path=lib/svc/manifest/system$ -> edit group bin sys>
+<transform link path=sbin/mount.vmblock$ -> drop>
+<transform file path=usr/sbin/mount.vmblock$ -> drop>
+<transform dir path=etc/pam.d$ -> drop>
+<transform file path=etc/pam.d/vmtoolsd$ -> drop>
+
+#
+# Were we to support kernel modules, we would need to use something like
+# the following transforms:
+#
+# <transform link path=sbin/mount.vmblock$ -> edit target ^.*$ usr/sbin/mount.vmblock>
+# <transform dir path=kernel$ -> edit group bin sys>
+# <transform dir path=kernel/drv$ -> edit group bin sys>
+# <transform dir path=kernel/drv/amd64$ -> edit group bin sys>
+# Note: use the "driver" action (see
+# http://docs.oracle.com/cd/E26502_01/html/E21383/pkgterms.html#gluea) for
+# drivers.

--- a/build/open-vm-tools/open-vm-tools.xml
+++ b/build/open-vm-tools/open-vm-tools.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+<!--
+    CDDL HEADER START
+
+    The contents of this file are subject to the terms of the
+    Common Development and Distribution License (the "License").
+    You may not use this file except in compliance with the License.
+
+    You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+    or http://www.opensolaris.org/os/licensing.
+    See the License for the specific language governing permissions
+    and limitations under the License.
+
+    When distributing Covered Code, include this CDDL HEADER in each
+    file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+    If applicable, add the following below this CDDL HEADER, with the
+    fields enclosed by brackets "[]" replaced with your own identifying
+    information: Portions Copyright [yyyy] [name of copyright owner]
+
+    CDDL HEADER END
+-->
+
+<!--
+    Copyright (c) 2014 by Delphix.
+    All rights reserved.
+-->
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type="manifest" name="system/virtualization/open-vm-tools">
+    <service version="1" type="service" name="system/virtualization/open-vm-tools">
+        <create_default_instance enabled="true" />
+
+        <dependency restart_on="none" type="service" name="multi_user_dependency" grouping="require_all">
+            <service_fmri value="svc:/milestone/multi-user"/>
+        </dependency>
+
+        <exec_method timeout_seconds="60" type="method" name="start"
+            exec="/usr/bin/vmtoolsd &amp;"
+            />
+        <exec_method timeout_seconds="60" type="method" name="stop"
+            exec=":kill"/>
+        <exec_method timeout_seconds="60" type="method" name="refresh"
+            exec=":kill -1"/> <!-- SIGHUP -->
+        <template>
+            <common_name>
+                <loctext xml:lang="C">
+                    Open Virtual Machine Tools
+                </loctext>
+            </common_name>
+            <description>
+                <loctext xml:lang="C">
+                    The Open Virtual Machine Tools project aims to provide a suite of open source virtualization utilities and drivers to improve the functionality and user experience of virtualization. The project currently runs in guest operating systems under VMware hypervisor.
+                </loctext>
+            </description>
+        </template>
+    </service>
+</service_bundle>

--- a/build/pkg-config/build.sh
+++ b/build/pkg-config/build.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/bash
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2014 by Delphix. All rights reserved.
+#
+
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=pkg-config
+VER=0.28
+VERHUMAN=$VER
+PKG=developer/pkg-config
+SUMMARY="A tool for generating compiler command line options"
+DESC="pkg-config is a helper tool used when compiling applications and libraries that helps you insert the correct compiler options on the command line, rather than hard-coding values on where to find libraries."
+
+BUILD_DEPENDS_IPS=
+RUN_DEPENDS_IPS=
+
+CONFIGURE_OPTS="--with-internal-glib"
+
+init
+download_source $PROG $PROG $VER
+prep_build
+build
+make_isa_stub
+make_package
+clean_up

--- a/build/pkg-config/local.mog
+++ b/build/pkg-config/local.mog
@@ -1,0 +1,26 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2014 by Delphix. All rights reserved.
+#
+
+license COPYING license=GPLv2


### PR DESCRIPTION
Provides an `open-vm-tools` package with none of the kernel modules and a `pkg-config` package that was necessary to build the `open-vm-tools` package.
