### PR TITLE
Port all build system changes from master to template branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build.log
+build.log.1
+tmp.repo/
+*.p5m.final

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,377 @@
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE Version 1.0
+
+1. Definitions.
+
+    1.1. "Contributor" means each individual or entity that creates
+         or contributes to the creation of Modifications.
+
+    1.2. "Contributor Version" means the combination of the Original
+         Software, prior Modifications used by a Contributor (if any),
+         and the Modifications made by that particular Contributor.
+
+    1.3. "Covered Software" means (a) the Original Software, or (b)
+         Modifications, or (c) the combination of files containing
+         Original Software with files containing Modifications, in
+         each case including portions thereof.
+
+    1.4. "Executable" means the Covered Software in any form other
+         than Source Code.
+
+    1.5. "Initial Developer" means the individual or entity that first
+         makes Original Software available under this License.
+
+    1.6. "Larger Work" means a work which combines Covered Software or
+         portions thereof with code not governed by the terms of this
+         License.
+
+    1.7. "License" means this document.
+
+    1.8. "Licensable" means having the right to grant, to the maximum
+         extent possible, whether at the time of the initial grant or
+         subsequently acquired, any and all of the rights conveyed
+         herein.
+
+    1.9. "Modifications" means the Source Code and Executable form of
+         any of the following:
+
+        A. Any file that results from an addition to, deletion from or
+           modification of the contents of a file containing Original
+           Software or previous Modifications;
+
+        B. Any new file that contains any part of the Original
+           Software or previous Modifications; or
+
+        C. Any new file that is contributed or otherwise made
+           available under the terms of this License.
+
+    1.10. "Original Software" means the Source Code and Executable
+          form of computer software code that is originally released
+          under this License.
+
+    1.11. "Patent Claims" means any patent claim(s), now owned or
+          hereafter acquired, including without limitation, method,
+          process, and apparatus claims, in any patent Licensable by
+          grantor.
+
+    1.12. "Source Code" means (a) the common form of computer software
+          code in which modifications are made and (b) associated
+          documentation included in or with such code.
+
+    1.13. "You" (or "Your") means an individual or a legal entity
+          exercising rights under, and complying with all of the terms
+          of, this License.  For legal entities, "You" includes any
+          entity which controls, is controlled by, or is under common
+          control with You.  For purposes of this definition,
+          "control" means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by
+          contract or otherwise, or (b) ownership of more than fifty
+          percent (50%) of the outstanding shares or beneficial
+          ownership of such entity.
+
+2. License Grants.
+
+    2.1. The Initial Developer Grant.
+
+    Conditioned upon Your compliance with Section 3.1 below and
+    subject to third party intellectual property claims, the Initial
+    Developer hereby grants You a world-wide, royalty-free,
+    non-exclusive license:
+
+        (a) under intellectual property rights (other than patent or
+            trademark) Licensable by Initial Developer, to use,
+            reproduce, modify, display, perform, sublicense and
+            distribute the Original Software (or portions thereof),
+            with or without Modifications, and/or as part of a Larger
+            Work; and
+
+        (b) under Patent Claims infringed by the making, using or
+            selling of Original Software, to make, have made, use,
+            practice, sell, and offer for sale, and/or otherwise
+            dispose of the Original Software (or portions thereof).
+
+        (c) The licenses granted in Sections 2.1(a) and (b) are
+            effective on the date Initial Developer first distributes
+            or otherwise makes the Original Software available to a
+            third party under the terms of this License.
+
+        (d) Notwithstanding Section 2.1(b) above, no patent license is
+            granted: (1) for code that You delete from the Original
+            Software, or (2) for infringements caused by: (i) the
+            modification of the Original Software, or (ii) the
+            combination of the Original Software with other software
+            or devices.
+
+    2.2. Contributor Grant.
+
+    Conditioned upon Your compliance with Section 3.1 below and
+    subject to third party intellectual property claims, each
+    Contributor hereby grants You a world-wide, royalty-free,
+    non-exclusive license:
+
+        (a) under intellectual property rights (other than patent or
+            trademark) Licensable by Contributor to use, reproduce,
+            modify, display, perform, sublicense and distribute the
+            Modifications created by such Contributor (or portions
+            thereof), either on an unmodified basis, with other
+            Modifications, as Covered Software and/or as part of a
+            Larger Work; and
+
+        (b) under Patent Claims infringed by the making, using, or
+            selling of Modifications made by that Contributor either
+            alone and/or in combination with its Contributor Version
+            (or portions of such combination), to make, use, sell,
+            offer for sale, have made, and/or otherwise dispose of:
+            (1) Modifications made by that Contributor (or portions
+            thereof); and (2) the combination of Modifications made by
+            that Contributor with its Contributor Version (or portions
+            of such combination).
+
+        (c) The licenses granted in Sections 2.2(a) and 2.2(b) are
+            effective on the date Contributor first distributes or
+            otherwise makes the Modifications available to a third
+            party.
+
+        (d) Notwithstanding Section 2.2(b) above, no patent license is
+            granted: (1) for any code that Contributor has deleted
+            from the Contributor Version; (2) for infringements caused
+            by: (i) third party modifications of Contributor Version,
+            or (ii) the combination of Modifications made by that
+            Contributor with other software (except as part of the
+            Contributor Version) or other devices; or (3) under Patent
+            Claims infringed by Covered Software in the absence of
+            Modifications made by that Contributor.
+
+3. Distribution Obligations.
+
+    3.1. Availability of Source Code.
+
+    Any Covered Software that You distribute or otherwise make
+    available in Executable form must also be made available in Source
+    Code form and that Source Code form must be distributed only under
+    the terms of this License.  You must include a copy of this
+    License with every copy of the Source Code form of the Covered
+    Software You distribute or otherwise make available.  You must
+    inform recipients of any such Covered Software in Executable form
+    as to how they can obtain such Covered Software in Source Code
+    form in a reasonable manner on or through a medium customarily
+    used for software exchange.
+
+    3.2. Modifications.
+
+    The Modifications that You create or to which You contribute are
+    governed by the terms of this License.  You represent that You
+    believe Your Modifications are Your original creation(s) and/or
+    You have sufficient rights to grant the rights conveyed by this
+    License.
+
+    3.3. Required Notices.
+
+    You must include a notice in each of Your Modifications that
+    identifies You as the Contributor of the Modification.  You may
+    not remove or alter any copyright, patent or trademark notices
+    contained within the Covered Software, or any notices of licensing
+    or any descriptive text giving attribution to any Contributor or
+    the Initial Developer.
+
+    3.4. Application of Additional Terms.
+
+    You may not offer or impose any terms on any Covered Software in
+    Source Code form that alters or restricts the applicable version
+    of this License or the recipients' rights hereunder.  You may
+    choose to offer, and to charge a fee for, warranty, support,
+    indemnity or liability obligations to one or more recipients of
+    Covered Software.  However, you may do so only on Your own behalf,
+    and not on behalf of the Initial Developer or any Contributor.
+    You must make it absolutely clear that any such warranty, support,
+    indemnity or liability obligation is offered by You alone, and You
+    hereby agree to indemnify the Initial Developer and every
+    Contributor for any liability incurred by the Initial Developer or
+    such Contributor as a result of warranty, support, indemnity or
+    liability terms You offer.
+
+    3.5. Distribution of Executable Versions.
+
+    You may distribute the Executable form of the Covered Software
+    under the terms of this License or under the terms of a license of
+    Your choice, which may contain terms different from this License,
+    provided that You are in compliance with the terms of this License
+    and that the license for the Executable form does not attempt to
+    limit or alter the recipient's rights in the Source Code form from
+    the rights set forth in this License.  If You distribute the
+    Covered Software in Executable form under a different license, You
+    must make it absolutely clear that any terms which differ from
+    this License are offered by You alone, not by the Initial
+    Developer or Contributor.  You hereby agree to indemnify the
+    Initial Developer and every Contributor for any liability incurred
+    by the Initial Developer or such Contributor as a result of any
+    such terms You offer.
+
+    3.6. Larger Works.
+
+    You may create a Larger Work by combining Covered Software with
+    other code not governed by the terms of this License and
+    distribute the Larger Work as a single product.  In such a case,
+    You must make sure the requirements of this License are fulfilled
+    for the Covered Software.
+
+4. Versions of the License.
+
+    4.1. New Versions.
+
+    Sun Microsystems, Inc. is the initial license steward and may
+    publish revised and/or new versions of this License from time to
+    time.  Each version will be given a distinguishing version number.
+    Except as provided in Section 4.3, no one other than the license
+    steward has the right to modify this License.
+
+    4.2. Effect of New Versions.
+
+    You may always continue to use, distribute or otherwise make the
+    Covered Software available under the terms of the version of the
+    License under which You originally received the Covered Software.
+    If the Initial Developer includes a notice in the Original
+    Software prohibiting it from being distributed or otherwise made
+    available under any subsequent version of the License, You must
+    distribute and make the Covered Software available under the terms
+    of the version of the License under which You originally received
+    the Covered Software.  Otherwise, You may also choose to use,
+    distribute or otherwise make the Covered Software available under
+    the terms of any subsequent version of the License published by
+    the license steward.
+
+    4.3. Modified Versions.
+
+    When You are an Initial Developer and You want to create a new
+    license for Your Original Software, You may create and use a
+    modified version of this License if You: (a) rename the license
+    and remove any references to the name of the license steward
+    (except to note that the license differs from this License); and
+    (b) otherwise make it clear that the license contains terms which
+    differ from this License.
+
+5. DISCLAIMER OF WARRANTY.
+
+    COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS"
+    BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED
+    SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR
+    PURPOSE OR NON-INFRINGING.  THE ENTIRE RISK AS TO THE QUALITY AND
+    PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU.  SHOULD ANY
+    COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE
+    INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY
+    NECESSARY SERVICING, REPAIR OR CORRECTION.  THIS DISCLAIMER OF
+    WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE.  NO USE OF
+    ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS
+    DISCLAIMER.
+
+6. TERMINATION.
+
+    6.1. This License and the rights granted hereunder will terminate
+    automatically if You fail to comply with terms herein and fail to
+    cure such breach within 30 days of becoming aware of the breach.
+    Provisions which, by their nature, must remain in effect beyond
+    the termination of this License shall survive.
+
+    6.2. If You assert a patent infringement claim (excluding
+    declaratory judgment actions) against Initial Developer or a
+    Contributor (the Initial Developer or Contributor against whom You
+    assert such claim is referred to as "Participant") alleging that
+    the Participant Software (meaning the Contributor Version where
+    the Participant is a Contributor or the Original Software where
+    the Participant is the Initial Developer) directly or indirectly
+    infringes any patent, then any and all rights granted directly or
+    indirectly to You by such Participant, the Initial Developer (if
+    the Initial Developer is not the Participant) and all Contributors
+    under Sections 2.1 and/or 2.2 of this License shall, upon 60 days
+    notice from Participant terminate prospectively and automatically
+    at the expiration of such 60 day notice period, unless if within
+    such 60 day period You withdraw Your claim with respect to the
+    Participant Software against such Participant either unilaterally
+    or pursuant to a written agreement with Participant.
+
+    6.3. In the event of termination under Sections 6.1 or 6.2 above,
+    all end user licenses that have been validly granted by You or any
+    distributor hereunder prior to termination (excluding licenses
+    granted to You by any distributor) shall survive termination.
+
+7. LIMITATION OF LIABILITY.
+
+    UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT
+    (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE
+    INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF
+    COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE
+    LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR
+    CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT
+    LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK
+    STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+    COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN
+    INFORMED OF THE POSSIBILITY OF SUCH DAMAGES.  THIS LIMITATION OF
+    LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL
+    INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT
+    APPLICABLE LAW PROHIBITS SUCH LIMITATION.  SOME JURISDICTIONS DO
+    NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR
+    CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT
+    APPLY TO YOU.
+
+8. U.S. GOVERNMENT END USERS.
+
+    The Covered Software is a "commercial item," as that term is
+    defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial
+    computer software" (as that term is defined at 48
+    C.F.R. 252.227-7014(a)(1)) and "commercial computer software
+    documentation" as such terms are used in 48 C.F.R. 12.212
+    (Sept. 1995).  Consistent with 48 C.F.R. 12.212 and 48
+    C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all
+    U.S. Government End Users acquire Covered Software with only those
+    rights set forth herein.  This U.S. Government Rights clause is in
+    lieu of, and supersedes, any other FAR, DFAR, or other clause or
+    provision that addresses Government rights in computer software
+    under this License.
+
+9. MISCELLANEOUS.
+
+    This License represents the complete agreement concerning subject
+    matter hereof.  If any provision of this License is held to be
+    unenforceable, such provision shall be reformed only to the extent
+    necessary to make it enforceable.  This License shall be governed
+    by the law of the jurisdiction specified in a notice contained
+    within the Original Software (except to the extent applicable law,
+    if any, provides otherwise), excluding such jurisdiction's
+    conflict-of-law provisions.  Any litigation relating to this
+    License shall be subject to the jurisdiction of the courts located
+    in the jurisdiction and venue specified in a notice contained
+    within the Original Software, with the losing party responsible
+    for costs, including, without limitation, court costs and
+    reasonable attorneys' fees and expenses.  The application of the
+    United Nations Convention on Contracts for the International Sale
+    of Goods is expressly excluded.  Any law or regulation which
+    provides that the language of a contract shall be construed
+    against the drafter shall not apply to this License.  You agree
+    that You alone are responsible for compliance with the United
+    States export administration regulations (and the export control
+    laws and regulation of any other countries) when You use,
+    distribute or otherwise make available any Covered Software.
+
+10. RESPONSIBILITY FOR CLAIMS.
+
+    As between Initial Developer and the Contributors, each party is
+    responsible for claims and damages arising, directly or
+    indirectly, out of its utilization of rights under this License
+    and You agree to work with Initial Developer and Contributors to
+    distribute such responsibility on an equitable basis.  Nothing
+    herein is intended or shall be deemed to constitute any admission
+    of liability.
+
+--------------------------------------------------------------------
+
+NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND
+DISTRIBUTION LICENSE (CDDL)
+
+For Covered Software in this distribution, this License shall
+be governed by the laws of the State of California (excluding
+conflict-of-law provisions).
+
+Any litigation relating to this License shall be subject to the
+jurisdiction of the Federal Courts of the Northern District of
+California and the state courts of the State of California, with
+venue lying in Santa Clara County, California.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Build System for OmniOS
+
+These scripts and tools are used to build new versions of OmniOS.
+
+Please see [the build instructions](http://omnios.omniti.com/wiki.php/BuildInstructions) for details on how to use these tools.

--- a/build/buildctl
+++ b/build/buildctl
@@ -1,0 +1,251 @@
+#!/usr/bin/bash
+
+NOBANNER=1
+batch_flag=""
+lint_flag=""
+if [ "${BATCH}" = 1 ]; then
+    echo "Enabling batch mode."
+    batch_flag="-b"
+fi
+. ../lib/functions.sh
+
+[ "${1}" == "licenses" ] && AUDIT_LICENSE=1
+
+# targets maps any valid package name to its build script.
+declare -A targets
+# fulltargets maps full package names to their build script.
+declare -A fulltargets
+# list of packages already built.
+declare -A already_built
+DEPENDENCY_CHECK="n"
+
+add_target() {
+	local pkg=$1
+	local build=$2
+	[[ -n ${fulltargets[$pkg]} ]] && \
+	    logerr "Target $pkg specified by ${fulltargets[$pkg]} and $build."
+	fulltargets+=([$pkg]=$build)
+
+	#
+	# Repeatedly strip off leading components to generate all valid
+	# names for this package. If more than one package has the same
+	# abbreviated name, the first one wins.
+	#
+	[[ -n ${targets[$pkg]} ]] || targets+=([$pkg]=$build)
+	while [[ $pkg =~ '/' ]]; do
+		pkg=${pkg#*/}
+		[[ -n ${targets[$pkg]} ]] || targets+=([$pkg]=$build)
+	done
+}
+
+declare -A licenses
+TCNT=0
+for build in */build*.sh
+do
+    for PKG in $(grep -v '##IGNORE##' $build | sed -e 's/^ +//' -e 's/ +#.+//' -e 's/=/ /g' -e 's/^.+make_package/make_package/g' | awk '{if($1=="PKG"){PKG=$2; print $2;} if($1=="make_package"){print PKG"="$2;}}')
+    do
+        if [ -n "`echo ${PKG} | grep '.='`" ] ; then
+            [ -z "${AUDIT_LICENSE}" ] && continue
+            MOG=`echo ${PKG} | sed -e 's/^.*=//'`
+            PKG=`echo ${PKG} | sed -e 's/=.*$//'`
+            LOCALMOG=`echo ${build} | sed -e 's:/.*$:/local.mog:'`
+            [ -f $MOG ] || MOG=""
+            [ -f $LOCALMOG ] || LOCALMOG=""
+            LICENSE=`nawk -F "[ =]" '/"/{gsub("\"", "")} /^license/ {print $3;}' $MOG $LOCALMOG /dev/null | xargs`
+            licenses+=([$PKG]=$LICENSE)
+            TCNT=$(($TCNT + 1))
+            print -f "."
+        else
+		add_target $PKG $build
+        fi
+    done
+done
+[ -n "${AUDIT_LICENSE}" ] && echo
+
+for manifest in */*.p5m
+do
+    for PKG in $(awk '/^set name=pkg.fmri/ {print $3;}' $manifest | sed -e 's/value=//' -e 's/.*\/\/[^\/]*\///g' -e 's/@.*//')
+    do
+        add_target $PKG $manifest
+    done
+done
+
+usage() {
+    echo $0
+    echo "    list [grep pattern]  (sorted alphabetically)"
+    echo "    list-build [grep pattern] (sorted in build order)"
+    echo "    licenses"
+    echo "    build <pkg> | all"
+    exit
+}
+
+bail() {
+    echo $*
+    exit
+}
+
+list() {
+    PAT=${1-.}
+    for target in "${!fulltargets[@]}"
+    do
+        if [[ "$PAT" = "." ]]; then
+            echo " * $target"
+        elif [[ -n $(echo "$target" | grep "$PAT") ]]; then
+            echo " * $target"
+        fi
+    done | sort
+}
+
+list_build() {
+    PAT=${1-.}
+    for target in "${!fulltargets[@]}"
+    do
+        if [[ "$PAT" = "." ]]; then
+            echo " * $target"
+        elif [[ -n $(echo "$target" | grep "$PAT") ]]; then
+            echo " * $target"
+        fi
+    done
+}
+
+build() {
+    if [[ -z "${targets[$1]}" ]]; then
+        bail "Unknown package: $1"
+    fi
+    if [[ "${already_built[$1]}" = "1" ]]; then
+	logmsg "--- This package was already built."
+    else
+    DIR=$(dirname ${targets[$1]})
+    pushd $DIR > /dev/null || bail "Cannot chdir to $DIR"
+        PKGSRVR=$DEFAULT_PKGSRVR
+        PKGPUBLISHER=$DEFAULT_PKGPUBLISHER
+        PKGROOT=`pwd`/root
+        if [[ -f environment ]]; then
+            logmsg "--- Setting new environment"
+            . environment
+        fi
+	if [[ -f dependencies && $DEPENDENCY_CHECK = "y" ]]; then
+	    for dep in `cat dependencies`
+	    do
+		logmsg "--------- Dependency on $dep"
+		if [[ "${already_built[$dep]}" = "1" ]]; then
+		    logmsg "----------- (already resolved)"
+		else
+		    logmsg "----------- (needs building)"
+		    pushd .. > /dev/null || bail "Cannot pop up"
+		    build $dep
+		    popd > /dev/null
+		fi
+	    done
+	fi
+        SCRIPT=$(basename ${targets[$1]})
+        if [[ -n $(echo $SCRIPT | grep ".p5m$") ]]; then
+            echo "Found a manifest file. Preparing it for publishing."
+            sed -e "s/@PKGPUBLISHER@/$PKGPUBLISHER/g; s/@RELVER@/$RELVER/g; s/@PVER@/$PVER/g;" < $SCRIPT > $SCRIPT.final
+            if [[ -f root.tar.bz2 ]]; then
+                echo "File archive found. Extracting..."
+                bzip2 -dc root.tar.bz2 | tar xf - || \
+                    bail "Failed to extract root.tar.bz2"
+                echo "Publishing from $SCRIPT.final"
+                pkgsend -s $PKGSRVR publish -d $PKGROOT $SCRIPT.final || \
+                    bail "pkgsend failed"
+                rm -rf $PKGROOT
+            # In case we just have a tree of files and not a tarball
+            elif [[ -d $PKGROOT ]]; then
+                echo "Publishing from $SCRIPT.final"
+                pkgsend -s $PKGSRVR publish -d $PKGROOT $SCRIPT.final || \
+                    bail "pkgsend failed"
+            # Else we just have a manifest to import
+            else
+                echo "Simple manifest to import... importing to $PKGSRVR"
+                pkgsend -s $PKGSRVR publish $SCRIPT.final || \
+                    bail "pkgsend failed"
+                rm $SCRIPT.final
+            fi
+        else
+            PATH=$PATH:. $SCRIPT -r $PKGSRVR $batch_flag $lint_flag || \
+                logerr "Unable to run $SCRIPT"
+        fi
+        already_built+=([$1]=1)
+    popd >/dev/null
+    fi
+}
+
+licenses() {
+    LCNT=0
+    for target in "${!licenses[@]}"
+    do
+        if [[ -n "${licenses[$target]}" ]]; then
+            echo " * $target     -> ${licenses[$target]}"
+            LCNT=$(($LCNT + 1))
+        fi
+    done | sort
+    if [ $LCNT -ne $TCNT ]; then
+        echo
+        echo "=== Packages missing license information ==="
+        for target in "${!licenses[@]}"
+        do
+            if [[ -z "${licenses[$target]}" ]]; then
+                echo " * $target"
+            fi
+        done | sort
+    fi
+}
+
+DEFAULT_PKGSRVR=$PKGSRVR
+DEFAULT_PKGPUBLISHER=$PKGPUBLISHER
+
+# When we get here, honor any -l or -b flags from the buildctl command line,
+# or even the environment.
+
+if [ "${BATCH}" = 1 ]; then
+    logmsg "Enabling batch mode."
+    batch_flag="-b"
+fi
+if [ "${SKIP_PKGLINT}" = 1 ]; then
+    logmsg "Disabling pkglint."
+    lint_flag="-l"
+fi
+
+case "$1" in
+    list)
+	list $2
+	exit
+	;;
+
+    list-build)
+	list_build $2
+	exit
+	;;
+
+    licenses)
+	licenses
+	exit
+	;;
+
+    build)
+	shift
+	tobuild=$*
+	if [ -z "$tobuild" ] || [ "$tobuild" == "all" ]; then
+		batch_flag="-b"
+		DEPENDENCY_CHECK="y"
+		for tgt in "${!fulltargets[@]}"; do
+                        # Uncomment the echo line if you want to see a
+                        # one-package-per-line status of what's building in
+                        # /tmp/debug.<PID>.
+                        # echo "Target = $tgt" >> /tmp/debug.$$
+			build $tgt
+		done
+	else
+		for tgt in $tobuild; do
+			build $tgt
+		done
+	fi
+        exit
+	;;
+
+    *)
+	usage
+	;;
+esac
+

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -20,18 +20,18 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Use is subject to license terms.
+# Copyright 2014 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright (c) 2014 by Delphix. All rights reserved.
 #
 #############################################################################
 # Configuration for the build system
 #############################################################################
 
-# Default branch
-RELVER=151008
+RELVER=151011
 PVER=0.$RELVER
 
-# Which server to fetch files from
+# Which server to fetch files from.
+# If $MIRROR begins with a '/', it is treated as a local directory.
 MIRROR=mirrors.omniti.com
 
 # Default prefix for packages (may be overridden)

--- a/lib/global-transforms.mog
+++ b/lib/global-transforms.mog
@@ -22,6 +22,7 @@
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright (c) 2014 by Delphix. All rights reserved.
 #
 # Make all directories usable
 <transform dir -> default mode 0755>
@@ -58,6 +59,7 @@
 <transform dir path=usr/share/aclocal$ -> set group other>
 <transform dir path=usr/share/lib$ -> set group sys>
 <transform dir path=var/lib$ -> set group other>
+<transform dir path=sbin$ -> set group sys>
 
 # These always exist due to SUNWcs, so we never need to worry about them
 <transform dir path=opt$ -> drop>
@@ -67,6 +69,7 @@
 <transform dir path=usr/kernel$ -> drop>
 <transform dir path=usr/lib/devfsadm$ -> drop>
 <transform dir path=usr/lib$ -> drop>
+<transform dir path=usr/share/man$ -> drop>
 <transform dir path=var$ -> drop>
 <transform dir path=var/run$ -> drop>
 <transform dir path=var/log$ -> drop>

--- a/tools/check_gcc_s_linkages.sh
+++ b/tools/check_gcc_s_linkages.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+GCC_S=`ldd /usr/lib/*.so 2>&1 | grep -v warning | \
+    awk '/^\//{LIB=$1;} /libstdc/{LIB=""} /gcc_s/{if(LIB){print LIB;}}' | \
+    grep -v gcc_s | cut -f1 -d:`
+GCC_S_64=`ldd /usr/lib/amd64/*.so 2>&1 | grep -v warning | \
+    awk '/^\//{LIB=$1;} /libstdc/{LIB=""} /gcc_s/{if(LIB){print LIB;}}' | \
+    grep -v gcc_s | cut -f1 -d:`
+
+CPLUSPLUS=`ldd /usr/lib/{,amd64/}*.so 2>&1 | grep -v warning | \
+    awk '/^\//{LIB=$1;} /libstdc\+\+/{print LIB;}' | \
+    grep -v 'libstdc++' | cut -f1 -d:`
+
+echo "G++ runtime (libstdc++.so) dependent libs:"
+echo "=================================================================="
+if [[ -n "$CPLUSPLUS" ]]; then
+    for so in $CPLUSPLUS; do
+        echo "\t$so"
+    done
+fi
+
+echo
+echo "GCC runtime (libgcc_s.so) dependentlibs (exluding C++):"
+echo "=================================================================="
+if [[ -n "$GCC_S" ]]; then
+    for so in $GCC_S; do
+        echo "\t$so"
+    done
+fi
+
+declare -A gcc_s_sym
+for sym in `nm /usr/lib/libgcc_s.so | \
+        sed -e 's/ *//g;' | \
+        awk -F\| '{if($5=="GLOB" && $4=="FUNC" && $7!="UNDEF"){print $8;}}'`; do
+    gcc_s_sym+=([$sym]=1)
+done
+for sym in `nm /usr/lib/libc.so | \
+        sed -e 's/ *//g;' | \
+        awk -F\| '{if($5=="GLOB" && $4=="FUNC" && $7!="UNDEF"){print $8;}}'`; do
+    unset gcc_s_sym[$sym]
+done
+
+declare -A gcc64_s_sym
+for sym in `nm /usr/lib/amd64/libgcc_s.so | \
+        sed -e 's/ *//g;' | \
+        awk -F\| '{if($5=="GLOB" && $4=="FUNC" && $7!="UNDEF"){print $8;}}'`; do
+    gcc64_s_sym+=([$sym]=1)
+done
+for sym in `nm /usr/lib/amd64/libc.so | \
+        sed -e 's/ *//g;' | \
+        awk -F\| '{if($5=="GLOB" && $4=="FUNC" && $7!="UNDEF"){print $8;}}'`; do
+    unset gcc64_s_sym[$sym]
+done
+
+echo
+echo "Libraries with unresolved symbols from libgcc_s:"
+echo "=================================================================="
+for so in /usr/lib/*.so; do
+    [[ "$so" = "/usr/lib/libstdc++.so" ]] && continue
+    syms=""
+    for sym in `nm $so | sed -e 's/ *//g;' | \
+            awk -F\| '{if($5=="GLOB" && $7=="UNDEF"){print $8;}}'`; do
+        if [[ -n ${gcc_s_sym[$sym]} ]]; then
+            syms="$sym $syms"
+        fi
+    done
+    if [[ -n "$syms" ]]; then
+        echo "\t$so: $syms"
+    fi
+done
+for so in /usr/lib/amd64/*.so; do
+    [[ "$so" = "/usr/lib/amd64/libstdc++.so" ]] && continue
+    syms=""
+    for sym in `nm $so | sed -e 's/ *//g;' | \
+            awk -F\| '{if($5=="GLOB" && $7=="UNDEF"){print $8;}}'`; do
+        if [[ -n ${gcc64_s_sym[$sym]} ]]; then
+            syms="$sym $syms"
+        fi
+    done
+    if [[ -n "$syms" ]]; then
+        echo "\t$so: $syms"
+    fi
+done
+

--- a/tools/omnios_pkg_version_change.pl
+++ b/tools/omnios_pkg_version_change.pl
@@ -1,0 +1,117 @@
+#!/usr/bin/perl
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2013 OmniTI Computer Consulting, Inc.  All rights reserved.
+#
+
+=head1 NAME
+
+omnios_pkg_version_change.pl - Generate a list of package changes between two OmniOS releases.
+
+=head1 SYNOPSIS
+
+  ./omnios_pkg_version_change.pl [-h] -p <previous> -n <new> -f <input file>
+
+=head1 DESCRIPTION
+
+This utility reads a file containing the output of C<pkg list -Hfav> and determines
+the package changes between two releases. It then prints a summary of changes in a
+format suitable for pasting into the release notes wiki page.
+
+=head2 Command Line Options
+
+=over
+
+=item --help / -h
+
+Display a list of options.
+
+=item --previous / -p
+
+The previous release that is the starting point for comparison. Expressed as a
+"nickname", or shortened form of the release, e.g. "006" for r151006.
+
+=item --new / -n
+
+The new release for which one wants to display the changes.  Expressed as a
+"nickname", or shortened form of the release, e.g. "008" for r151008.
+
+=item --file / -f
+
+Input file from which the package FMRIs are read. It should contain the output
+of C<pkg list -Hfav> on a system that can see both the previous release's
+packages as well as the new.
+
+=back
+
+=cut
+
+use warnings;
+use strict;
+use Getopt::Long;
+
+my ($previous_release, $new_release, $input_file, $help) = (0,0,'',0);
+
+GetOptions(
+  "p|prev=i"  => \$previous_release,
+  "n|new=i"   => \$new_release,
+  "f|file=s"  => \$input_file,
+  "h|help"    => sub { $help++ }
+);
+
+if ( ! $previous_release || ! $new_release || ! $input_file || $help ) {
+  print "Options:\n";
+  print "\t-p|--prev  Previous release nickname (006, 06, 6)\n";
+  print "\t-n|--new   New release nickname (008, 08, 8)\n";
+  print "\t-f|--file  Input file name\n";
+  print "\t-h|--help  This output\n";
+  exit 0;
+}
+
+$previous_release = "151" . sprintf("%03d", $previous_release);
+$new_release      = "151" . sprintf("%03d", $new_release);
+
+my $regex = "5.11-0.($previous_release|$new_release)";
+
+my %versions = ();
+
+open IN,"<$input_file"
+  or die "Failed to open file $input_file: $!\n";
+while (<IN>) {
+  my $line = $_;
+  if ( $line =~ /$regex/ ) {
+    my $omnios_ver = $1;
+    $line =~ /^pkg:\/\/[^\/]+\/([^\@]+)\@([^\s]+)/;
+    my ($pkg,$ver) = ($1,$2);
+    my ($comp_ver,$other) = split(/,/,$ver);
+
+    if ( ! $versions{$pkg} || ! $versions{$pkg}{$omnios_ver} ) {
+      $versions{$pkg}{$omnios_ver} = $comp_ver;
+    }
+  }
+}
+close IN;
+
+print " * Package changes ([+] Added, [-] Removed, [*] Changed)\n";
+
+foreach my $pkg ( sort keys %versions ) {
+  if ( $versions{$pkg}{$previous_release} && ! $versions{$pkg}{$new_release} ) {
+    print "   * [-] $pkg\n";
+  }
+  elsif ( ! $versions{$pkg}{$previous_release} && $versions{$pkg}{$new_release} ) {
+    print "   * [+] $pkg $versions{$pkg}{$new_release}\n";
+  }
+  elsif ( $versions{$pkg}{$previous_release} ne $versions{$pkg}{$new_release} ) {
+    print "   * [*] $pkg $versions{$pkg}{$previous_release} -> $versions{$pkg}{$new_release}\n";
+  }
+}


### PR DESCRIPTION
I just spent several hours in merge hell wrt. PR #40 since our branch niksula:master was built on top of omniti-labs:template, but there have been a lot of changes in omniti-labs:master which are not in template (but also some changes vice versa). There is a problem with the way the omnios-build repository is set up at the moment: changes to the build _system_ can happen in any branch (forks/clones are branches too!), and merging between different branches is not directly possible because they also contain build _script_ changes -- a workaround is that every branch has to cherry-pick all build system changes from all other branches, but that does not scale and is terribly tedious to do. This PR is a result of cleanup from merging omniti-labs:master into omniti-labs:template and using filter-branch magic to prune commits that touched any directory under build/. This solves the immediate problem of syncing up my branches with master's build system without getting my scripts touched; I just merge the template branch. I submit this PR because I believe this work will be useful to others as well.

Further, it is my opinion that it would be easier for everyone if the build _system_ were maintained separately so that all branches/forks could just track omniti-labs:master and merge stuff from there without fear of getting their _scripts_ changed. I'd love to discuss options to do that further (on IRC perhaps).
