### PR TITLE
don't shadow global PKG variable in ask_to_install

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -160,8 +160,8 @@ ask_to_continue() {
 }
 
 ask_to_install() {
-    PKG=$1
-    MSG=$2
+    local PKG=$1
+    local MSG=$2
     if [[ -n "$AUTOINSTALL" ]]; then
         logmsg "Auto-installing $PKG..."
         logcmd $SUDO pkg install $PKG || logerr "pkg install $PKG failed"


### PR DESCRIPTION
ask_to_install breaks the current package build because it uses the global
variable PKG. Observe:

```
===== Build started at Mon Oct  6 14:37:29 EEST 2014 =====
Package name: service/storage/znapzend
[ ... ]
--- Build-time dependency niksula/perl/mojo-ioloop-forkcall not found Install/Abort? (i/a) i   
[ ... ]
Making package
--- Generating package manifest from /tmp/build_ltirkkon/niksula_perl_mojo-ioloop-forkcall_pkg
```

Note that the package manifest is not generated from the correct place (and in fact the package will be generated with the wrong name, ie. that of the last installed build-time dep).
