### PR TITLE
use PERL_MAKEFILE_OPTS, as is defined in config.sh

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1046,7 +1046,7 @@ buildperl32() {
     logmsg "Building 32-bit"
     export ISALIST="$ISAPART"
     local OPTS
-    OPTS=${MAKEFILE_OPTS//_ARCH_/}
+    OPTS=${PERL_MAKEFILE_OPTS//_ARCH_/}
     OPTS=${OPTS//_ARCHBIN_/$ISAPART}
     if [[ -f Makefile.PL ]]; then
         make_clean
@@ -1074,7 +1074,7 @@ buildperl64() {
     pushd $TMPDIR/$BUILDDIR > /dev/null
     logmsg "Building 64-bit"
     local OPTS
-    OPTS=${MAKEFILE_OPTS//_ARCH_/$ISAPART64}
+    OPTS=${PERL_MAKEFILE_OPTS//_ARCH_/$ISAPART64}
     OPTS=${OPTS//_ARCHBIN_/$ISAPART64}
     if [[ -f Makefile.PL ]]; then
         make_clean

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1046,15 +1046,17 @@ buildperl32() {
     logmsg "Building 32-bit"
     export ISALIST="$ISAPART"
     local OPTS
-    OPTS=${PERL_MAKEFILE_OPTS//_ARCH_/}
-    OPTS=${OPTS//_ARCHBIN_/$ISAPART}
     if [[ -f Makefile.PL ]]; then
+        OPTS=${PERL_MAKEFILE_OPTS//_ARCH_/}
+        OPTS=${OPTS//_ARCHBIN_/$ISAPART}
         make_clean
         makefilepl32 $OPTS
         make_prog
         [[ -n $PERL_MAKE_TEST ]] && make_param test
         make_pure_install
     elif [[ -f Build.PL ]]; then
+        OPTS=${PERL_BUILDPL_OPTS//_ARCH_/}
+        OPTS=${OPTS//_ARCHBIN_/$ISAPART}
         build_clean
         buildpl32 $OPTS
         build_prog
@@ -1074,15 +1076,17 @@ buildperl64() {
     pushd $TMPDIR/$BUILDDIR > /dev/null
     logmsg "Building 64-bit"
     local OPTS
-    OPTS=${PERL_MAKEFILE_OPTS//_ARCH_/$ISAPART64}
-    OPTS=${OPTS//_ARCHBIN_/$ISAPART64}
     if [[ -f Makefile.PL ]]; then
+        OPTS=${PERL_MAKEFILE_OPTS//_ARCH_/$ISAPART64}
+        OPTS=${OPTS//_ARCHBIN_/$ISAPART64}
         make_clean
         makefilepl64 $OPTS
         make_prog
         [[ -n $PERL_MAKE_TEST ]] && make_param test
         make_pure_install
     elif [[ -f Build.PL ]]; then
+        OPTS=${PERL_BUILDPL_OPTS//_ARCH_/$ISAPART64}
+        OPTS=${OPTS//_ARCHBIN_/$ISAPART64}
         build_clean
         buildpl64 $OPTS
         build_prog


### PR DESCRIPTION
Previously buildperl32/64 used MAKEFILE_OPTS, instead of the existing PERL_MAKEFILE_OPTS from config.sh.