### PR TITLE
faster build dependency check

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -404,7 +404,7 @@ verify_depends() {
         esac
         deppkgs="$deppkgs $i"
     done
-    if [ -n "$deppkgs" ]; then
+    if [[ -n "$deppkgs" ]]; then
         if ! pkg list -H $deppkgs >/dev/null; then
             ask_to_install "$deppkgs" '--- Build dependencies unsatisfied'
         fi

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -387,6 +387,7 @@ verify_depends() {
     if [[ -z "$BUILD_DEPENDS_IPS" && -n "$DEPENDS_IPS" ]]; then
         BUILD_DEPENDS_IPS=$DEPENDS_IPS
     fi
+    local deppkgs=""
     for i in $BUILD_DEPENDS_IPS; do
         # Trim indicators to get the true name (see make_package for details)
         case ${i:0:1} in
@@ -401,9 +402,13 @@ verify_depends() {
                 continue
                 ;;
         esac
-        pkg info $i > /dev/null 2<&1 ||
-            ask_to_install "$i" "--- Build-time dependency $i not found"
+        deppkgs="$deppkgs $i"
     done
+    if [ -n "$deppkgs" ]; then
+        if ! pkg list -H $deppkgs >/dev/null; then
+            ask_to_install "$deppkgs" '--- Build dependencies unsatisfied'
+        fi
+    fi
 }
 
 #############################################################################


### PR DESCRIPTION
Previously the check for build dependencies was O(n), since it called pkg info for each dependency. This patch makes it O(1), and additionally installs all missing dependencies with only one question if running interactively.

Excerpt from interactive build with patch, some missing dependencies but some installed:

    ===== Build started at Fri Nov 14 10:44:33 EET 2014 =====
    Package name: niksula/perl5/Mail-SpamAssassin
    Selected flavor: None (use -f to specify a flavor)
    Selected build arch: both
    Extra dependency: None (use -d to specify a version)
    Verifying dependencies

    pkg list: no packages matching 'pkg:/niksula/perl5/Mail-DKIM, pkg:/niksula/perl5/DB_File, pkg:/niksula/perl5/IO-Socket-INET6, pkg:/niksula/perl5/Net-DNS' installed
    --- Build dependencies unsatisfied Install/Abort? (i/a) i

and from the build log:

    Verifying dependencies
    Running: pfexec pkg install pkg:/niksula/runtime/perl@5.20 pkg:/niksula/runtime/perl@5.20 pkg:/niksula/perl5/HTML-Parser pkg:/niksula/perl5/NetAddr-IP pkg:/niksula/perl5/Mail-DKIM pkg:/niksula/perl5/Net-DNS pkg:/niksula/perl5/Digest-SHA1 pkg:/niksula/perl5/DB_File pkg:/niksula/perl5/Encode-Detect pkg:/niksula/perl5/HTTP-Date pkg:/niksula/perl5/IO-Socket-INET6 security/gnupg
               Packages to install:  4
           Create boot environment: No
    Create backup boot environment: No

    Download: niksula/perl5/Mail-DKIM ...  Done
    Download: niksula/perl5/DB_File ...  Done
    Download: niksula/perl5/IO-Socket-INET6 ...  Done
    Download: niksula/perl5/Net-DNS ...  Done
    Install Phase ...  Done
    Package State Update Phase ...  Done
    Image State Update Phase ...  Done
    Reading Existing Index ...  Done
    Indexing Packages ...  Done
