### PR TITLE
NTP should depend on name-services and routing-setup

### DIFF
--- a/build/ntp/root/lib/svc/manifest/network/ntp.xml
+++ b/build/ntp/root/lib/svc/manifest/network/ntp.xml
@@ -51,6 +51,22 @@
 		    <service_fmri value='svc:/system/filesystem/minimal' />
 	</dependency>
 
+	<dependency 
+		name='name-services'
+		grouping='optional_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri value='svc:/milestone/name-services' />
+	</dependency>
+
+	<dependency 
+		name='routing-setup'
+		grouping='optional_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri value='svc:/network/routing-setup' />
+	</dependency>
+
 <!--	<dependent
 	    name='ntp_multi-user'
 	    grouping='optional_all'


### PR DESCRIPTION
If you are using the domain name in ntp.conf, you must "svcadm restart ntp" after the reboot.
NTP should depend on name-services and routing-setup.

[OmniOS-discuss] NTP server needs restarting to be usable
http://lists.omniti.com/pipermail/omnios-discuss/2014-December/004019.html