### PR TITLE
build lint libraries for zlib, libxml2, trousers, and OpenSSL

### DIFF
--- a/build/libxml2/build.sh
+++ b/build/libxml2/build.sh
@@ -34,7 +34,7 @@ SUMMARY="$PROG - XML C parser and toolkit"
 DESC="$SUMMARY"
 
 DEPENDS_IPS="compress/xz@5.0 system/library/gcc-4-runtime library/zlib@1.2.8"
-BUILD_DEPENDS_IPS="$DEPENDS_IPS"
+BUILD_DEPENDS_IPS="$DEPENDS_IPS developer/sunstudio12.1"
 
 fix_python_install() {
     logcmd mkdir -p $DESTDIR/usr/lib/python2.6/vendor-packages
@@ -81,6 +81,7 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
+make_lintlibs xml2 /usr/lib /usr/include/libxml2 "libxml/*.h"
 fix_python_install
 make_isa_stub
 install_license

--- a/build/openssl/build.sh
+++ b/build/openssl/build.sh
@@ -35,6 +35,7 @@ SUMMARY="$PROG - A toolkit for Secure Sockets Layer (SSL v2/v3) and Transport La
 DESC="$SUMMARY"
 
 DEPENDS_IPS="SUNWcs system/library system/library/gcc-4-runtime library/zlib@1.2.8"
+BUILD_DEPENDS_IPS="$DEPENDS_IPS developer/sunstudio12.1"
 
 NO_PARALLEL_MAKE=1
 
@@ -133,6 +134,8 @@ patch_source
 prep_build
 build
 move_libs
+make_lintlibs crypto /lib /usr/include "openssl/!(ssl*|*tls*).h"
+make_lintlibs ssl /lib /usr/include "openssl/{ssl,*tls}*.h"
 make_isa_stub
 make_package
 clean_up

--- a/build/trousers/build.sh
+++ b/build/trousers/build.sh
@@ -34,7 +34,7 @@ PKG=library/security/trousers  # Package name (without prefix)
 SUMMARY="trousers - TCG Software Stack - software for accessing a TPM device"
 DESC="$SUMMARY ($VER)"
 
-BUILD_DEPENDS_IPS="developer/build/libtool developer/build/automake developer/build/autoconf"
+BUILD_DEPENDS_IPS="developer/build/libtool developer/build/automake developer/build/autoconf developer/sunstudio12.1"
 DEPENDS_IPS="system/library/gcc-4-runtime library/security/openssl@1.0.2"
 
 LIBS="-lbsm -lnsl -lsocket -lgen -lscf -lresolv"
@@ -104,6 +104,7 @@ patch_source
 preprep_build
 prep_build
 build
+make_lintlibs tspi /usr/lib /usr/include "{tss,trousers}/*.h"
 make_isa_stub
 install_license
 make_package

--- a/build/zlib/build.sh
+++ b/build/zlib/build.sh
@@ -10,6 +10,8 @@ SUMMARY="$PROG - A massively spiffy yet delicately unobtrusive compression libra
 DESC="$SUMMARY"
 
 DEPENDS_IPS="system/library/gcc-4-runtime"
+BUILD_DEPENDS_IPS="$DEPENDS_IPS developer/sunstudio12.1"
+
 
 CFLAGS="-DNO_VIZ"
 
@@ -44,6 +46,7 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
+make_lintlibs z /usr/lib /usr/include
 make_isa_stub
 install_license
 make_package


### PR DESCRIPTION
Hi,

this change adds support for buildinging lint libraries to omnios-build. Lint libs are built by default for zlib, libxml2, trousers, and OpenSSL, as those are the external dependencies of illumos-gate that lint wants to verify against.

I have tested this on OmniOS in February, there have been a few changes to the packages since then but I don't expect it to break. We've had that in our nexenta-build since late February and are compiling nza-kernel with no lint warnings against that.

Hans

Hans