### PR TITLE
add iperf man page symlink

### DIFF
--- a/build/iperf/build.sh
+++ b/build/iperf/build.sh
@@ -42,7 +42,8 @@ CONFIGURE_OPTS="--bindir=$PREFIX/bin"
 LDFLAGS="-lsocket -lnsl"
 
 make_symlinks()  {
-	logcmd ln -s iperf3 $DESTDIR/usr/bin/iperf
+    logcmd ln -s iperf3 $DESTDIR/usr/bin/iperf
+    logcmd ln -s iperf3.1 $DESTDIR/usr/share/man/man1/iperf.1
 }
 
 init


### PR DESCRIPTION
also turn the previous line's tab into a four-space indent (per the vim option 'et' present in the file's modeline)