### PR TITLE
Cleaning up dependency checking.  This was checking the wrong things.

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -237,7 +237,8 @@ BasicRequirements(){
     [[ -f /usr/lib/crt1.o ]] || needed+=" developer/library/lint"
     [[ -x /usr/bin/gmake ]] || needed+=" developer/build/gnu-make"
     [[ -f /usr/include/sys/types.h ]] || needed+=" system/header"
-    [[ -f /usr/include/math.h ]] || needed+=" system/library/math"
+    [[ -f /usr/lib/libm.so ]] || needed+=" system/library/math"
+    [[ -f /usr/include/math.h ]] || needed+=" system/library/math/header-math"
     if [[ -n "$needed" ]]; then
         logmsg "You appear to be missing some basic build requirements."
         logmsg "To fix this run:"


### PR DESCRIPTION
lib/functions.sh was looking at /usr/include/math.h
for system/library/math, which doesn't contain math.h.  math.h is added by
system/library/math/header-math, which was previously unchecked.

/usr/lib/libm.so has been added as a check for system/library/math, and the
math.h dep checker was pointed to system/library/math/header-math.

It's unclear if system/library/math/header-math and system/library math
are both required for all packages, so I took the cautious route.