### PR TITLE
use ssh-keygen -A for openssh host key generation

### DIFF
--- a/build/openssh/method-sshd
+++ b/build/openssh/method-sshd
@@ -9,21 +9,11 @@
 
 CONFDIR=/etc/ssh
 
-create_host_key() {
-    TYPE=$1
-    FILE=$2
-    /usr/bin/ssh-keygen -t $TYPE -N '' -f $FILE || \
-        exit $SMF_EXIT_ERR_CONFIG
-}
-
 [ -x /usr/sbin/sshd ] || exit $SMF_EXIT_ERR_FATAL
 
 case $1 in
     "start")
-        [ -f $CONFDIR/ssh_host_dsa_key ] || create_host_key dsa $CONFDIR/ssh_host_dsa_key
-        [ -f $CONFDIR/ssh_host_rsa_key ] || create_host_key rsa $CONFDIR/ssh_host_rsa_key
-        [ -f $CONFDIR/ssh_host_ecdsa_key ] || create_host_key ecdsa $CONFDIR/ssh_host_ecdsa_key
-        [ -f $CONFDIR/ssh_host_ed25519_key ] || create_host_key ed25519 $CONFDIR/ssh_host_ed25519_key
+        /usr/bin/ssh-keygen -A || exit $SMF_EXIT_ERR_FATAL
         /usr/sbin/sshd
         ;;
 esac        


### PR DESCRIPTION
Turns out there's a better way to handle host keys for OpenSSH; letting ssh-keygen handle it.