### PR TITLE
Omniti ms

### DIFF
--- a/build/postfix/build.sh
+++ b/build/postfix/build.sh
@@ -44,7 +44,7 @@ configure32() {
 
 configure64() {
     logmsg "--- Configure (make makefiles)"
-    logcmd $MAKE makefiles CCARGS='-DNO_NIS \
+    logcmd $MAKE makefiles CCARGS='-m64 -DNO_NIS \
         -DDEF_COMMAND_DIR=\"/opt/omni/sbin\" \
         -DDEF_CONFIG_DIR=\"/opt/omni/etc/postfix\" \
         -DDEF_DAEMON_DIR=\"/opt/omni/libexec/postfix\" \

--- a/build/postfix/files/postfix.xml
+++ b/build/postfix/files/postfix.xml
@@ -13,7 +13,7 @@
             <service_fmri value="svc:/system/filesystem/local"/>
         </dependency>
         <exec_method type="method" name="start"
-            exec="/opt/omni/libexec/postfix/master" timeout_seconds="60"/>
+            exec="/opt/omni/sbin/postfix start" timeout_seconds="60"/>
         <exec_method type="method" name="stop" exec=":kill"
             timeout_seconds="60"/>
         <property_group name="startd" type="framework">


### PR DESCRIPTION
Postfix binaries and libs in omniti-ms repo are not 64-bit, see field "elfbits" in package manifest. Option '-m64' fixes this. 
Also, I did not find advantage to start postfix by executing "$PREFIX/libexec/master" instead of "$PREFIX/sbin/postfix start"