### PR TITLE
Update coreutils to 8.24

### DIFF
--- a/build/coreutils/build.sh
+++ b/build/coreutils/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=coreutils          # App name
-VER=8.23                # App version
+VER=8.24                # App version
 PKG=file/gnu-coreutils  # Package name (without prefix)
 SUMMARY="coreutils - GNU core utilities"
 DESC="GNU core utilities ($VER)"

--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -121,7 +121,7 @@ depend fmri=driver/usb@0.5.11,5.11-@PVER@ type=require
 depend fmri=driver/virtualization/kvm@1.0.3-@PVER@ type=require
 depend fmri=driver/xvm/pv@0.5.11,5.11-@PVER@ type=require
 depend fmri=editor/vim@7.3,5.11-@PVER@ type=require
-depend fmri=file/gnu-coreutils@8.23,5.11-@PVER@ type=require
+depend fmri=file/gnu-coreutils@8.24,5.11-@PVER@ type=require
 depend fmri=file/gnu-findutils@4.4.2,5.11-@PVER@ type=require
 depend fmri=install/beadm@0.5.11,5.11-@PVER@ type=require
 depend fmri=library/c++/sigcpp@2.4,5.11-@PVER@ type=require

--- a/build/jeos/omnios-userland.p5m
+++ b/build/jeos/omnios-userland.p5m
@@ -37,7 +37,7 @@ depend fmri=developer/versioning/git@2.4,5.11-@PVER@ type=incorporate
 depend fmri=developer/versioning/mercurial@3,5.11-@PVER@ type=incorporate
 depend fmri=driver/virtualization/kvm@1.0,5.11-@PVER@ type=incorporate
 depend fmri=editor/vim@7.4,5.11-@PVER@ type=incorporate
-depend fmri=file/gnu-coreutils@8.23,5.11-@PVER@ type=incorporate
+depend fmri=file/gnu-coreutils@8.24,5.11-@PVER@ type=incorporate
 depend fmri=file/gnu-findutils@4.4.2,5.11-@PVER@ type=incorporate
 depend fmri=install/distribution-constructor@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=install/installadm@0.5.11,5.11-@PVER@ type=incorporate


### PR DESCRIPTION
This is a simple change to update the `file/gnu-coreutils` from version `8.23` to `8.24`. I haven't done any testing of this, but given the previous patches updating the coreutils version, this looked simple enough.

Please let me know if there's any more work that needs to happen to get this change landed. Or, alternatively, if you'd rather keep OmniOS at version `8.23`, then feel free to close this without landing it.

Thanks!