### PR TITLE
update zsh to 5.1.1

### DIFF
--- a/build/jeos/omnios-userland.p5m
+++ b/build/jeos/omnios-userland.p5m
@@ -94,7 +94,7 @@ depend fmri=service/network/ntp@4.2.8,5.11-@PVER@ type=incorporate
 depend fmri=shell/bash@4.3,5.11-@PVER@ type=incorporate
 depend fmri=shell/pipe-viewer@1.5,5.11-@PVER@ type=incorporate
 depend fmri=shell/tcsh@6.18.1,5.11-@PVER@ type=incorporate
-depend fmri=shell/zsh@5.0,5.11-@PVER@ type=incorporate
+depend fmri=shell/zsh@5.1,5.11-@PVER@ type=incorporate
 depend fmri=system/install@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=system/install/auto-install@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=system/install/auto-install/auto-install-common@0.5.11,5.11-@PVER@ type=incorporate

--- a/build/zsh/build.sh
+++ b/build/zsh/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=zsh
-VER=5.0.7
+VER=5.1.1
 VERHUMAN=$VER
 PKG=shell/zsh
 SUMMARY="Z shell"


### PR DESCRIPTION
Fixes https://github.com/omniti-labs/omnios-build/issues/63. Tested working (though I had to build & install coreutils 8.24 by hand because it's not yet available from the bloody repo, yet is required by the new omnios-userland)