### PR TITLE
build tmux against ncurses

### DIFF
--- a/build/tmux/build.sh
+++ b/build/tmux/build.sh
@@ -39,7 +39,7 @@ LDIR=libevent-${LIBEVENT_VER}-stable
 BUILDARCH=32
 CONFIGURE_OPTS_32="$CONFIGURE_OPTS_32 --bindir=/usr/bin"
 CPPFLAGS="-I$TMPDIR/$PROG-$VER/$LDIR/include/event2 \
-    -I$TMPDIR/$PROG-$VER/$LDIR/include"
+    -I$TMPDIR/$PROG-$VER/$LDIR/include -I/usr/include/ncurses"
 CFLAGS="-std=c99 -D_XPG6 -D_POSIX_C_SOURCE=200112L"
 LDFLAGS="-L$TMPDIR/$PROG-$VER/$LDIR/.libs -lsocket -lnsl -lsendfile"
 

--- a/build/tmux/patches/series
+++ b/build/tmux/patches/series
@@ -1,3 +1,4 @@
 tmux.h.patch
 errno-for-errno.patch
 job-libevheader.patch
+use-ncurses.patch -p0

--- a/build/tmux/patches/use-ncurses.patch
+++ b/build/tmux/patches/use-ncurses.patch
@@ -1,0 +1,11 @@
+--- configure.orig	Wed Oct 14 12:29:10 2015
++++ configure	Wed Oct 14 12:29:23 2015
+@@ -5002,7 +5002,7 @@
+   return 0;
+ }
+ _ACEOF
+-for ac_lib in '' terminfo curses ncurses tinfo; do
++for ac_lib in '' terminfo ncurses tinfo; do
+   if test -z "$ac_lib"; then
+     ac_res="none required"
+   else


### PR DESCRIPTION
Fixes #67.

I didn't look very deeply into the underlying issue, but I've run into enough issues with the "system" libcurses that I've developed a disdain for it. Could be that tmux is assuming something about curses that's not true with libcurses, but in any case using ncurses instead fixes it. It probably also supports newer terminals better, but I'm just assuming. Maybe it's a bit of a blunt approach -- you're of course free to explore the issue further if you want to keep using libcurses in tmux instead ;)

I'd like to see this issue fixed in 151014 too, because it's a rather nasty bug.