### PR TITLE
Include nvme driver in default install

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -108,6 +108,7 @@ depend fmri=driver/storage/mega_sas@0.5.11,5.11-@PVER@ type=require
 depend fmri=driver/storage/mpt_sas@0.5.11,5.11-@PVER@ type=require
 depend fmri=driver/storage/mr_sas@0.5.11,5.11-@PVER@ type=require
 depend fmri=driver/storage/nv_sata@0.5.11,5.11-@PVER@ type=require
+depend fmri=driver/storage/nvme@0.5.11,5.11-@PVER@ type=require
 depend fmri=driver/storage/pmcs@0.5.11,5.11-@PVER@ type=require
 depend fmri=driver/storage/sbp2@0.5.11,5.11-@PVER@ type=require
 depend fmri=driver/storage/scsa1394@0.5.11,5.11-@PVER@ type=require

--- a/build/jeos/illumos-gate.p5m
+++ b/build/jeos/illumos-gate.p5m
@@ -520,6 +520,7 @@ depend fmri=driver/storage/mega_sas@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=driver/storage/mpt_sas@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=driver/storage/mr_sas@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=driver/storage/nv_sata@0.5.11,5.11-@PVER@ type=incorporate
+depend fmri=driver/storage/nvme@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=driver/storage/pmcs@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=driver/storage/sbp2@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=driver/storage/scsa1394@0.5.11,5.11-@PVER@ type=incorporate


### PR DESCRIPTION
This would be required for NVMe install support per https://github.com/omniti-labs/kayak/issues/11