### PR TITLE
restart isc-dhcp, ntp, openssh services on update

### DIFF
--- a/build/isc-dhcp/local.mog
+++ b/build/isc-dhcp/local.mog
@@ -35,4 +35,9 @@
 <transform file	path=var/db/dhcp.leases -> set preserve true>
 <transform file	path=var/db/dhcp6.leases -> set preserve true>
 
+<transform file path=usr/sbin/dhcpd$ -> set restart_fmri svc:/network/service/dhcp:ipv4>
+<transform file path=usr/sbin/dhcpd$ -> add restart_fmri svc:/network/service/dhcp:ipv6>
+<transform file path=(usr/sbin/dhcrelay|lib/svc/method/dhcrelay)$ -> set restart_fmri svc:/network/service/dhcrelay:ipv4>
+<transform file path=(usr/sbin/dhcrelay|lib/svc/method/dhcrelay)$ -> add restart_fmri svc:/network/service/dhcrelay:ipv6>
+
 license LICENSE license=ISC

--- a/build/ntp/local.mog
+++ b/build/ntp/local.mog
@@ -30,4 +30,5 @@
 <transform file path=etc/security/.*/ntp$ -> set mode 0444>
 <transform file path=usr/sbin/.* -> set mode 0555>
 <transform file path=usr/lib/inet/.* -> set mode 0555>
+<transform file path=(usr/lib/inet/ntpd|lib/svc/method/ntp)$ -> set restart_fmri svc:/network/ntp:default>
 license COPYRIGHT license="UD Open Source"

--- a/build/openssh/server.mog
+++ b/build/openssh/server.mog
@@ -14,3 +14,4 @@ user ftpuser=false gcos-field="OpenSSH privsep user" group=sshd login-shell=/bin
 <transform file path=usr/share/man/man4/ssh_config.4 -> drop>
 <transform file path=usr/share/man/man1m/ssh-keysign.1m -> drop>
 <transform file path=usr/share/man/man1m/ssh-pkcs11-helper.1m -> drop>
+<transform file path=(usr/sbin/sshd|lib/svc/method/sshd|etc/ssh/sshd_config)$ -> set restart_fmri svc:/network/ssh:default>


### PR DESCRIPTION
Figured this would be useful based on the recent omnios-discuss thread.

Built test packages; pkg update -v mentioned restart_fmri for the correct services when installing them.

There are some other .xml files in the omnios-build tree but I didn't touch those packages because I don't happen to use the services in question and thus don't really know which files should get the actuators.