### PR TITLE
change sendmail depend type to 'group' in entire

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -279,7 +279,7 @@ depend fmri=service/file-system/smb@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/hal@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/network/network-clients@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/network/ntp@4.2.8,5.11-@PVER@ type=require
-depend fmri=service/network/smtp/sendmail@8.14.4,5.11-@PVER@ type=require
+depend fmri=service/network/smtp/sendmail@8.14.4,5.11-@PVER@ type=group
 depend fmri=service/network/ssh@0.5.11,5.11-@PVER@ fmri=network/openssh-server type=require-any
 depend fmri=service/picl@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/resource-pools/poold@0.5.11,5.11-@PVER@ type=require


### PR DESCRIPTION
Tested that this works nicely and still installs sendmail by default, while allowing it to be removed. Ref #69

Based this on 151016 because that's what people are complaining about, but should be cherry-pickable on master too.