### PR TITLE
pull PAM & lastlogin patches from joyent and --disable-lastlog for ssh

### DIFF
--- a/build/openssh/build.sh
+++ b/build/openssh/build.sh
@@ -53,6 +53,7 @@ CONFIGURE_OPTS="
     --with-ssl-engine
     --with-pam
     --with-audit=solaris
+    --disable-lastlog
     "
 
 install_smf() {


### PR DESCRIPTION
This should be applied to make OpenSSH's last login messages work correctly after the fix for https://www.illumos.org/issues/6057 (although since they don't currently work correctly with UsePAM yes, it won't hurt much to apply this beforehand either if you want).

The PAM patch does mean that UsePAM is always enabled, but I don't think that's a problem.