### PR TITLE
bind: catman complains about missing man page file due to dangling sy…

### DIFF
--- a/build/bind/local.mog
+++ b/build/bind/local.mog
@@ -65,6 +65,7 @@
 <transform file path=usr/share/man/man8/named-.* -> drop>
 <transform file path=usr/share/man/man8/rndc-confgen.8 -> drop>
 <transform file path=usr/share/man/man8/ddns-confgen.8 -> drop>
+<transform file path=usr/share/man/man8/tsig-keygen.8 -> drop>
 <transform file path=usr/share/man/man8/pkcs11-.* -> drop>
 <transform dir  path=var -> drop>
 license COPYRIGHT license=ISC


### PR DESCRIPTION
…mlink

We drop /usr/share/man/man8/ddns-confgen.8 but /usr/share/man/man8/tsig-keygen.8 is created as a symlink to it. The result is a dangling symlink. So we need to drop the tsig-keygen.8 man page as well.