### PR TITLE
[UNTESTED] Places libraries in /lib in a more traditional manner

### DIFF
--- a/build/gcc51/build-libgcc_s.sh
+++ b/build/gcc51/build-libgcc_s.sh
@@ -54,9 +54,9 @@ do
 done
 mkdir -p $DESTDIR/usr/lib
 cp /opt/gcc-${VER}/lib/libgcc_s.so.1 $DESTDIR/usr/lib/libgcc_s.so.1
-ln -s /usr/lib/libgcc_s.so.1 $DESTDIR/usr/lib/libgcc_s.so
+ln -s libgcc_s.so.1 $DESTDIR/usr/lib/libgcc_s.so
 mkdir -p $DESTDIR/usr/lib/amd64
 cp /opt/gcc-${VER}/lib/amd64/libgcc_s.so.1 $DESTDIR/usr/lib/amd64/libgcc_s.so.1
-ln -s /usr/lib/amd64/libgcc_s.so.1 $DESTDIR/usr/lib/amd64/libgcc_s.so
+ln -s libgcc_s.so.1 $DESTDIR/usr/lib/amd64/libgcc_s.so
 make_package runtime.mog
 clean_up

--- a/build/gcc51/build-libstdc++.sh
+++ b/build/gcc51/build-libstdc++.sh
@@ -84,23 +84,23 @@ cp ${GCC46_LOC}/$LIB.6.0.16 $DESTDIR/usr/lib/$LIB.6.0.16
 cp ${GCC47_LOC}/$LIB.6.0.17 $DESTDIR/usr/lib/$LIB.6.0.17
 cp ${GCC48_LOC}/$LIB.6.0.18 $DESTDIR/usr/lib/$LIB.6.0.18
 cp /opt/gcc-${VER}/lib/$LIB.6.0.21 $DESTDIR/usr/lib/$LIB.6.0.21 || logerr "Failed to copy 6.0.21"
-ln -s /usr/lib/$LIB.6.0.21 $DESTDIR/usr/lib/$LIB.6
-ln -s /usr/lib/$LIB.6.0.21 $DESTDIR/usr/lib/$LIB
+ln -s $LIB.6.0.21 $DESTDIR/usr/lib/$LIB.6
+ln -s $LIB.6.0.21 $DESTDIR/usr/lib/$LIB
 cp /opt/gcc-4.4.4/lib/amd64/$LIB.6.0.13 $DESTDIR/usr/lib/amd64/$LIB.6.0.13
 cp ${GCC46_LOC}/amd64/$LIB.6.0.16 $DESTDIR/usr/lib/amd64/$LIB.6.0.16
 cp ${GCC47_LOC}/amd64/$LIB.6.0.17 $DESTDIR/usr/lib/amd64/$LIB.6.0.17
 cp ${GCC48_LOC}/amd64/$LIB.6.0.18 $DESTDIR/usr/lib/amd64/$LIB.6.0.18
 cp /opt/gcc-${VER}/lib/amd64/$LIB.6.0.21 $DESTDIR/usr/lib/amd64/$LIB.6.0.21 || logerr "Failed to copy 6.0.21 (amd64)"
-ln -s /usr/lib/amd64/$LIB.6.0.21 $DESTDIR/usr/lib/amd64/$LIB.6
-ln -s /usr/lib/amd64/$LIB.6.0.21 $DESTDIR/usr/lib/amd64/$LIB
+ln -s $LIB.6.0.21 $DESTDIR/usr/lib/amd64/$LIB.6
+ln -s $LIB.6.0.21 $DESTDIR/usr/lib/amd64/$LIB
 
 LIB=libssp.so
 cp /opt/gcc-${VER}/lib/$LIB.0.0.0 $DESTDIR/usr/lib/$LIB.0.0.0
-ln -s /usr/lib/$LIB.0.0.0 $DESTDIR/usr/lib/$LIB.0
-ln -s /usr/lib/$LIB.0.0.0 $DESTDIR/usr/lib/$LIB
+ln -s $LIB.0.0.0 $DESTDIR/usr/lib/$LIB.0
+ln -s $LIB.0.0.0 $DESTDIR/usr/lib/$LIB
 cp /opt/gcc-${VER}/lib/amd64/$LIB.0.0.0 $DESTDIR/usr/lib/amd64/$LIB.0.0.0
-ln -s /usr/lib/amd64/$LIB.0.0.0 $DESTDIR/usr/lib/amd64/$LIB.0
-ln -s /usr/lib/amd64/$LIB.0.0.0 $DESTDIR/usr/lib/amd64/$LIB
+ln -s $LIB.0.0.0 $DESTDIR/usr/lib/amd64/$LIB.0
+ln -s $LIB.0.0.0 $DESTDIR/usr/lib/amd64/$LIB
 
 make_package runtime.mog
 clean_up

--- a/build/libxml2/build.sh
+++ b/build/libxml2/build.sh
@@ -76,6 +76,26 @@ make_install64() {
         logerr "--- Make install failed"
 }
 
+# Relocate the libs to /lib, to match upstream
+move_libs() {
+    logcmd mkdir -p $DESTDIR/lib/amd64
+    logcmd ln -s $DESTDIR/lib/64 amd64
+    logcmd mv $DESTDIR/usr/lib/lib* $DESTDIR/lib || \
+        logerr "failed to move libs (32-bit)"
+    logcmd mv $DESTDIR/usr/lib/amd64/lib* $DESTDIR/lib/amd64 || \
+        logerr "failed to move libs (64-bit)"
+    pushd $DESTDIR/usr/lib >/dev/null
+    logcmd ln -s ../../lib/libxml2.so.2.9.3 libxml2.so
+    logcmd ln -s ../../lib/libxml2.so.2.9.3 libxml2.so.2
+    logcmd ln -s ../../lib/libxml2.so.2.9.3 libxml2.so.2.9.3
+    popd >/dev/null
+    pushd $DESTDIR/usr/lib/amd64 >/dev/null
+    logcmd ln -s ../../../lib/64/libxml2.so.2.9.3 libxml2.so
+    logcmd ln -s ../../../lib/64/libxml2.so.2.9.3 libxml2.so.2
+    logcmd ln -s ../../../lib/64/libxml2.so.2.9.3 libxml2.so.2.9.3
+    popd>/dev/null
+}
+
 init
 download_source $PROG $PROG $VER
 patch_source
@@ -85,5 +105,6 @@ make_lintlibs xml2 /usr/lib /usr/include/libxml2 "libxml/*.h"
 fix_python_install
 make_isa_stub
 install_license
+move_libs
 make_package
 clean_up

--- a/build/openssl/build.sh
+++ b/build/openssl/build.sh
@@ -85,7 +85,7 @@ move_libs() {
     logmsg "link up certs"
     logcmd rmdir $DESTDIR/usr/ssl/certs ||
         logerr "Failed to remove /usr/ssl/certs"
-    logcmd ln -s /etc/ssl/certs $DESTDIR/usr/ssl/certs ||
+    logcmd ln -s ../../etc/ssl/certs $DESTDIR/usr/ssl/certs ||
         logerr "Failed to link up /usr/ssl/certs -> /etc/ssl/certs"
     logmsg "Relocating libs from usr/lib to lib"
     logcmd mv $DESTDIR/usr/lib/64 $DESTDIR/usr/lib/amd64

--- a/build/openssl/build.sh
+++ b/build/openssl/build.sh
@@ -96,16 +96,16 @@ move_libs() {
         logerr "Failed to move libs (64-bit)"
     logmsg "--- Making usr/lib symlinks"
     pushd $DESTDIR/usr/lib > /dev/null
-    logcmd ln -s /lib/libssl.so.1.0.0 libssl.so
-    logcmd ln -s /lib/libssl.so.1.0.0 libssl.so.1.0.0
-    logcmd ln -s /lib/libcrypto.so.1.0.0 libcrypto.so
-    logcmd ln -s /lib/libcrypto.so.1.0.0 libcrypto.so.1.0.0
+    logcmd ln -s ../../lib/libssl.so.1.0.0 libssl.so
+    logcmd ln -s ../../lib/libssl.so.1.0.0 libssl.so.1.0.0
+    logcmd ln -s ../../lib/libcrypto.so.1.0.0 libcrypto.so
+    logcmd ln -s ../../lib/libcrypto.so.1.0.0 libcrypto.so.1.0.0
     popd > /dev/null
     pushd $DESTDIR/usr/lib/amd64 > /dev/null
-    logcmd ln -s /lib/amd64/libssl.so.1.0.0 libssl.so
-    logcmd ln -s /lib/amd64/libssl.so.1.0.0 libssl.so.1.0.0
-    logcmd ln -s /lib/amd64/libcrypto.so.1.0.0 libcrypto.so
-    logcmd ln -s /lib/amd64/libcrypto.so.1.0.0 libcrypto.so.1.0.0
+    logcmd ln -s ../../../lib/amd64/libssl.so.1.0.0 libssl.so
+    logcmd ln -s ../../../lib/amd64/libssl.so.1.0.0 libssl.so.1.0.0
+    logcmd ln -s ../../../lib/amd64/libcrypto.so.1.0.0 libcrypto.so
+    logcmd ln -s ../../../lib/amd64/libcrypto.so.1.0.0 libcrypto.so.1.0.0
     popd > /dev/null
 }
 


### PR DESCRIPTION
Make an OmniOS systems library layout smell more like a traditional illumos system, such that an omnios-based `$ADJUNCT_PROTO` is more foolproof.

The OpenSSL change is a necessity, the libxml2 and zlib changes were noticed because of something I'd really consider to be a bug in `check_rtime`.  But it seems to me that matching the traditional layout here is more generally beneficial, so in an ideal world I'd fix both (I'm working on the `check_rtime` fix for illumos, too).

I have tested this stuff only _very_ lightly, by building package manifests and looking at them.  I don't have a setup to allow for further testing right now, sadly.