### PR TITLE
Add comments, alternate default to ntp.conf sample

### DIFF
--- a/build/ntp/root/etc/inet/ntp.conf.sample
+++ b/build/ntp/root/etc/inet/ntp.conf.sample
@@ -1,15 +1,23 @@
 driftfile /var/lib/ntp/ntp.drift 
 
 
-restrict default ignore # Deny everyone by default
+# Default to ignore for safety -- no incoming packets are trusted.
+# You will probably want to change this; see below.
+restrict default ignore
+
+# If you have reasonable firewall rules that prevent unsolicited incoming
+# traffic, you may choose this less-restrictive default, and comment out
+# the above.
+#restrict default limited kod nomodify notrap nopeer
+
 restrict 127.0.0.1      # Allow localhost full access
-restrict ::1            # Same
+restrict ::1            # Same, for IPv6
 
 # Allow these servers to view the time
 # Uncomment and change the network address as appropriate
 #restrict 10.9.8.0 mask 255.255.255.0  kod  nomodify notrap nopeer
 
-# Server selection
+# Peer selection
 # See http://support.ntp.org/bin/view/Servers/WebHome for more information
 # You will probably want to change these.
 server 0.pool.ntp.org


### PR DESCRIPTION
The default ignore setting is safe, but results in a server that cannot
sync time. Provide an alternate default, assuming the server has a
firewall guarding it against unsolicited inbound traffic.