### PR TITLE
Add fio 2.12

### DIFF
--- a/build/fio/build.sh
+++ b/build/fio/build.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/bash
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2011-2013 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Copyright (c) 2014, 2016 by Delphix. All rights reserved.
+#
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=fio        # App name
+VER=2.12        # App version
+VERHUMAN=$VER   # Human-readable version
+#PVER=          # Branch (set in config.sh, override here if needed)
+PKG=benchmark/fio # Package name (e.g. library/foo)
+SUMMARY="Flexible IO Tester" # One-liner, must be filled in
+DESC="Flexible IO Tester" # Longer description, must be filled in
+PATH=/usr/gnu/bin:/opt/csw/bin:$PATH # The source will only unpack using GNU tar
+NOSCRIPTSTUB=1  # Don't make isa wrappers for scripts
+
+BUILD_DEPENDS_IPS=
+RUN_DEPENDS_IPS=
+
+CONFIGURE_OPTS=
+CONFIGURE_OPTS_32=
+CONFIGURE_OPTS_64="--extra-cflags=-m64"
+
+make_install32() {
+	logcmd $MAKE DESTDIR=${DESTDIR} bindir="/usr/bin/i386" install || \
+	    logerr "--- Make install failed"
+}
+
+make_install64() {
+	logcmd $MAKE DESTDIR=${DESTDIR} bindir="/usr/bin/amd64" install || \
+	    logerr "--- Make install failed"
+}
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+make_isa_stub
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:

--- a/build/fio/local.mog
+++ b/build/fio/local.mog
@@ -1,0 +1,19 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2015, 2016 by Delphix. All rights reserved.
+#
+
+license COPYING license=GPLv2
+license MORAL-LICENSE license=GPLv2
+set name=info.classification \
+    value=org.opensolaris.category.2008:System/Services

--- a/build/fio/patches/Makefile.patch
+++ b/build/fio/patches/Makefile.patch
@@ -1,0 +1,19 @@
+--- fio-2.12.pristine/Makefile	Mon Jun 13 21:42:44 2016
++++ fio-2.12/Makefile	Wed Jul 20 19:16:13 2016
+@@ -285,12 +285,15 @@
+ else
+ 	INSTALL = install
+ endif
+-prefix = $(INSTALL_PREFIX)
++prefix = /usr
+ bindir = $(prefix)/bin
+ 
+ ifeq ($(CONFIG_TARGET_OS), Darwin)
+ mandir = /usr/share/man
+ sharedir = /usr/share/fio
++else ifeq ($(CONFIG_TARGET_OS), SunOS)
++mandir = $(prefix)/share/man
++sharedir = $(prefix)/share/fio
+ else
+ mandir = $(prefix)/man
+ sharedir = $(prefix)/share/fio

--- a/build/fio/patches/fio2gnuplot.patch
+++ b/build/fio/patches/fio2gnuplot.patch
@@ -1,0 +1,21 @@
+diff -bur fio-2.1.10.pristine/tools/plot/fio2gnuplot fio-2.1.10/tools/plot/fio2gnuplot
+--- fio-2.1.10.pristine/tools/plot/fio2gnuplot	2014-06-10 15:18:38.000000000 -0400
++++ fio-2.1.10/tools/plot/fio2gnuplot	2014-07-29 13:02:35.000000000 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/python2.6
+ #
+ #  Copyright (C) 2013 eNovance SAS <licensing@enovance.com>
+ #  Author: Erwan Velu  <erwan@enovance.com>
+@@ -401,9 +401,9 @@
+     force_keep_temp_files=False
+ 
+     if not os.path.isfile(gpm_dir+'math.gpm'):
+-	    gpm_dir="/usr/local/share/fio/"
++	    gpm_dir="/usr/share/fio/"
+     	    if not os.path.isfile(gpm_dir+'math.gpm'):
+-		    print "Looks like fio didn't get installed properly as no gpm files found in '/usr/share/fio' or '/usr/local/share/fio'\n"
++		    print "Looks like fio didn't get installed properly as no gpm files found in '/usr/share/fio'\n"
+ 		    sys.exit(3)
+ 
+     try:

--- a/build/fio/patches/os-solaris.h.patch
+++ b/build/fio/patches/os-solaris.h.patch
@@ -1,0 +1,10 @@
+--- fio-2.12.pristine/os/os-solaris.h	Mon Jun 13 21:42:44 2016
++++ fio-2.12/os/os-solaris.h	Wed Jul 13 21:12:33 2016
+@@ -12,6 +12,7 @@
+ #include <sys/mman.h>
+ #include <sys/dkio.h>
+ #include <sys/byteorder.h>
++#include <limits.h>
+ 
+ #include "../file.h"
+ 

--- a/build/fio/patches/series
+++ b/build/fio/patches/series
@@ -1,0 +1,3 @@
+Makefile.patch
+os-solaris.h.patch
+fio2gnuplot.patch


### PR DESCRIPTION
This diff adds `fio` version 2.12.

Upstream bugs:
- `DLPX-45328 FIO Version should be upgraded for ZFS performance tests`
- `QA-4431 fio 2.1.10 refuses to terminate even with a specified runtime`
- `DLPX-31514 include fio in pkg-build-gate`